### PR TITLE
Added Group Capacity to CSV map

### DIFF
--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -821,6 +821,7 @@ namespace Bulldozer.CSV
         private const int GroupDayOfWeek = 21;              /* String [Optional] */
         private const int GroupTime = 22;                   /* String [Optional] */
         private const int GroupDescription = 23;            /* String [Optional] */
+        private const int GroupCapacity = 24;               /* Int [Optional] */
 
         #endregion Group Constants
 

--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -56,7 +56,7 @@ namespace Bulldozer.CSV
             // Look for custom attributes in the Individual file
             var allFields = csvData.TableNodes.FirstOrDefault().Children.Select( ( node, index ) => new { node = node, index = index } ).ToList();
             var customAttributes = allFields
-                .Where( f => f.index > GroupDescription )
+                .Where( f => f.index > GroupCapacity )
                 .ToDictionary( f => f.index, f => f.node.Name );
 
             var groupAttributes = new AttributeService( lookupContext ).GetByEntityTypeId( new Group().TypeId ).ToList();
@@ -193,6 +193,20 @@ namespace Bulldozer.CSV
                     var groupOrder = 9999;
                     int.TryParse( row[GroupOrder], out groupOrder );
                     currentGroup.Order = groupOrder;
+
+                    //
+                    // Set the group's capacity
+                    //
+                    var capacity = row[GroupCapacity].AsIntegerOrNull();
+                    if ( capacity.HasValue )
+                    {
+                        currentGroup.GroupCapacity = capacity;
+
+                        if ( groupType.GroupCapacityRule == GroupCapacityRule.None )
+                        {
+                            groupType.GroupCapacityRule = GroupCapacityRule.Hard;
+                        }
+                    }
 
                     //
                     // Set the group's schedule

--- a/Bulldozer.CSV/SampleCSVs/10 - Group.csv
+++ b/Bulldozer.CSV/SampleCSVs/10 - Group.csv
@@ -1,9 +1,9 @@
-GroupId,GroupName,GroupCreatedDate,GroupType,GroupParentGroupId,GroupActive,GroupOrder,GroupCampus,GroupAddress,GroupAddress2,GroupCity,GroupState,GroupZip,GroupCountry,GroupSecondaryAddress,GroupSecondaryAddress2,GroupSecondaryCity,GroupSecondaryState,GroupSecondaryZip,GroupSecondaryCountry,GroupNamedLocation,GroupDayOfWeek,GroupTime,GroupDescription,^SG Import^Topic^V
-100,Small Group Tree,2/14/2010,Small Group Section,,Yes,0,MAIN,,,,,,,,,,,,,,,,,
-110,Fairbanks,,Small Group Section,100,Yes,0,MAIN,,,,,,,,,,,,,,,,,
-120,Kodiak,,Small Group Section,100,No,0,MAIN,,,,,,,,,,,,,,,,,
-130,Nome,,Small Group Section,100,Yes,0,MAIN,,,,,,,,,,,,,,,,,
-111,Ice Cold Weasels,,Small Group,110,,0,MAIN,1101 Cushman Street,,Fairbanks,AK,99701,,,,,,,,,,,,
-112,Slippery Otters,,Small Group,110,Yes,0,MAIN,800 Cushman Street,,Fairbanks,AK,99701,,,,,,,,,Wednesday,18:00:00,,Kids Praise
-COTG_1,Church Wide Events,09/09/2009,Church Wide Events,Attendance_History,YES,0,,,,,,,,,,,,,,,,,,
-COT_1,General Attendance,09/09/2009,Church Wide Events,COTG_1,YES,0,,,,,,,,,,,,,,General Location,,,,
+GroupId,GroupName,GroupCreatedDate,GroupType,GroupParentGroupId,GroupActive,GroupOrder,GroupCampus,GroupAddress,GroupAddress2,GroupCity,GroupState,GroupZip,GroupCountry,GroupSecondaryAddress,GroupSecondaryAddress2,GroupSecondaryCity,GroupSecondaryState,GroupSecondaryZip,GroupSecondaryCountry,GroupNamedLocation,GroupDayOfWeek,GroupTime,GroupDescription,GroupCapacity,^SG Import^Topic^V
+100,Small Group Tree,2/14/2010,Small Group Section,,Yes,0,MAIN,,,,,,,,,,,,,,,,,,
+110,Fairbanks,,Small Group Section,100,Yes,0,MAIN,,,,,,,,,,,,,,,,,,
+120,Kodiak,,Small Group Section,100,No,0,MAIN,,,,,,,,,,,,,,,,,,
+130,Nome,,Small Group Section,100,Yes,0,MAIN,,,,,,,,,,,,,,,,,,
+111,Ice Cold Weasels,,Small Group,110,,0,MAIN,1101 Cushman Street,,Fairbanks,AK,99701,,,,,,,,,,,,25,
+112,Slippery Otters,,Small Group,110,Yes,0,MAIN,800 Cushman Street,,Fairbanks,AK,99701,,,,,,,,,Wednesday,18:00:00,,25,Kids Praise
+COTG_1,Church Wide Events,09/09/2009,Church Wide Events,Attendance_History,YES,0,,,,,,,,,,,,,,,,,,,
+COT_1,General Attendance,09/09/2009,Church Wide Events,COTG_1,YES,0,,,,,,,,,,,,,,General Location,,,,,

--- a/Bulldozer.FellowshipOne/SampleCampusInsert.sql
+++ b/Bulldozer.FellowshipOne/SampleCampusInsert.sql
@@ -1,0 +1,36 @@
+/* ================================================================ *
+	This script adds custom campuses to the base Rock install so other
+	fields can use the name and shortcodes as lookup values.
+
+	Rock v8.7
+* ================================================================ */
+
+DECLARE @True bit = 1
+DECLARE @False bit = 0
+DECLARE @Order int = 0
+DECLARE @CampusLocationType int = ( SELECT [Id] FROM [DefinedValue] WHERE [Guid] = 'C0D7AE35-7901-4396-870E-3AAF472AAE88' )
+
+
+-- Insert Campus Locations
+INSERT [dbo].[Location] ([Name], [Guid], [IsActive], [LocationTypeValueId])
+VALUES
+	('Online', NEWID(), @True, @CampusLocationType),
+	('Downtown', NEWID(), @True, @CampusLocationType),
+	('West Side', NEWID(), @True, @CampusLocationType),
+	('East Side', NEWID(), @True, @CampusLocationType)
+
+
+-- Insert Additional Campuses
+INSERT [dbo].[Campus] ([IsSystem], [Name], [ShortCode], [Guid], [IsActive])
+VALUES 
+	(@False, 'Online', 'Online', NEWID(), @True),
+	(@False, 'Downtown', 'DT', NEWID(), @True),
+	(@False, 'West Side', 'WS', NEWID(), @True),
+	(@False, 'East Side', 'ES', NEWID(), @True)
+
+
+-- Update Campus Location
+UPDATE c
+SET c.[LocationId] = l.[Id]
+FROM [dbo].[Campus] c
+JOIN [dbo].[Location] l ON c.[Name] LIKE l.[Name]


### PR DESCRIPTION
**This is a new required field in the Group.csv file.**  

If the Group Type Capacity Rule is set to `None` it will modify the Group Type Capacity Rule to `Hard` when setting a `GroupCapacity`.  i.e. If the Group Type has an existing rule of `Soft` or `Hard` it will _not_ be modified.