### PR TITLE
b-gm-Data Import Fixes

### DIFF
--- a/Bulldozer.CSV/Maps/Financial.cs
+++ b/Bulldozer.CSV/Maps/Financial.cs
@@ -60,8 +60,7 @@ namespace Bulldozer.CSV
                 var fundName = row[FinancialFundName] as string;
                 var fundDescription = row[FinancialFundDescription] as string;
                 var fundGLAccount = row[FinancialFundGLAccount] as string;
-                var isFundActiveKey = row[FinancialFundIsActive];
-                var isFundActive = isFundActiveKey.AsType<bool?>();
+                var isFundActive = ( bool? ) ParseBoolOrDefault( row[FinancialFundIsActive], false );
                 var fundStartDateKey = row[FinancialFundStartDate] as string;
                 var fundStartDate = fundStartDateKey.AsType<DateTime?>();
                 var fundEndDateKey = row[FinancialFundEndDate] as string;
@@ -71,8 +70,7 @@ namespace Bulldozer.CSV
                 var fundParentIdKey = row[FinancialFundParentID];
                 var fundParentId = fundParentIdKey.AsType<int?>();
                 var fundPublicName = row[FinancialFundPublicName] as string;
-                var isTaxDeductibleKey = row[FinancialFundIsTaxDeductible];
-                var isTaxDeductible = isTaxDeductibleKey.AsType<bool?>();
+                var isTaxDeductible = ( bool? ) ParseBoolOrDefault( row[FinancialFundIsTaxDeductible], false );
                 var campusName = row[FinancialFundCampusName];
 
                 if ( !string.IsNullOrWhiteSpace( fundName ) )
@@ -908,10 +906,8 @@ namespace Bulldozer.CSV
                     var subFund = row[SubFundName] as string;
                     var fundGLAccount = row[FundGLAccount] as string;
                     var subFundGLAccount = row[SubFundGLAccount] as string;
-                    var isFundActiveKey = row[FundIsActive];
-                    var isFundActive = isFundActiveKey.AsType<bool?>();
-                    var isSubFundActiveKey = row[SubFundIsActive];
-                    var isSubFundActive = isSubFundActiveKey.AsType<bool?>();
+                    var isFundActive = ( bool? ) ParseBoolOrDefault( row[FundIsActive], false );
+                    var isSubFundActive = ( bool? ) ParseBoolOrDefault( row[SubFundIsActive], false );
                     var statedValueKey = row[StatedValue];
                     var statedValue = statedValueKey.AsType<decimal?>();
                     var amountKey = row[Amount];
@@ -1284,10 +1280,8 @@ namespace Bulldozer.CSV
                         var subFund = row[SubFundName] as string;
                         var fundGLAccount = row[FundGLAccount] as string;
                         var subFundGLAccount = row[SubFundGLAccount] as string;
-                        var isFundActiveKey = row[FundIsActive];
-                        var isFundActive = isFundActiveKey.AsType<bool?>();
-                        var isSubFundActiveKey = row[SubFundIsActive];
-                        var isSubFundActive = isSubFundActiveKey.AsType<bool?>();
+                        var isFundActive = ( bool? ) ParseBoolOrDefault( row[FundIsActive], false );
+                        var isSubFundActive = ( bool? ) ParseBoolOrDefault( row[SubFundIsActive], false );
 
                         if ( !string.IsNullOrWhiteSpace( fundName ) )
                         {

--- a/Bulldozer.CSV/Maps/Financial.cs
+++ b/Bulldozer.CSV/Maps/Financial.cs
@@ -60,7 +60,7 @@ namespace Bulldozer.CSV
                 var fundName = row[FinancialFundName] as string;
                 var fundDescription = row[FinancialFundDescription] as string;
                 var fundGLAccount = row[FinancialFundGLAccount] as string;
-                var isFundActive = ( bool? ) ParseBoolOrDefault( row[FinancialFundIsActive], false );
+                var isFundActive = ParseBoolOrDefault( row[FinancialFundIsActive], null );
                 var fundStartDateKey = row[FinancialFundStartDate] as string;
                 var fundStartDate = fundStartDateKey.AsType<DateTime?>();
                 var fundEndDateKey = row[FinancialFundEndDate] as string;
@@ -70,7 +70,7 @@ namespace Bulldozer.CSV
                 var fundParentIdKey = row[FinancialFundParentID];
                 var fundParentId = fundParentIdKey.AsType<int?>();
                 var fundPublicName = row[FinancialFundPublicName] as string;
-                var isTaxDeductible = ( bool? ) ParseBoolOrDefault( row[FinancialFundIsTaxDeductible], false );
+                var isTaxDeductible = ParseBoolOrDefault( row[FinancialFundIsTaxDeductible], null );
                 var campusName = row[FinancialFundCampusName];
 
                 if ( !string.IsNullOrWhiteSpace( fundName ) )
@@ -906,8 +906,8 @@ namespace Bulldozer.CSV
                     var subFund = row[SubFundName] as string;
                     var fundGLAccount = row[FundGLAccount] as string;
                     var subFundGLAccount = row[SubFundGLAccount] as string;
-                    var isFundActive = ( bool? ) ParseBoolOrDefault( row[FundIsActive], false );
-                    var isSubFundActive = ( bool? ) ParseBoolOrDefault( row[SubFundIsActive], false );
+                    var isFundActive = ParseBoolOrDefault( row[FundIsActive], null );
+                    var isSubFundActive = ParseBoolOrDefault( row[SubFundIsActive], null );
                     var statedValueKey = row[StatedValue];
                     var statedValue = statedValueKey.AsType<decimal?>();
                     var amountKey = row[Amount];
@@ -1280,8 +1280,8 @@ namespace Bulldozer.CSV
                         var subFund = row[SubFundName] as string;
                         var fundGLAccount = row[FundGLAccount] as string;
                         var subFundGLAccount = row[SubFundGLAccount] as string;
-                        var isFundActive = ( bool? ) ParseBoolOrDefault( row[FundIsActive], false );
-                        var isSubFundActive = ( bool? ) ParseBoolOrDefault( row[SubFundIsActive], false );
+                        var isFundActive = ParseBoolOrDefault( row[FundIsActive], null );
+                        var isSubFundActive = ParseBoolOrDefault( row[SubFundIsActive], null );
 
                         if ( !string.IsNullOrWhiteSpace( fundName ) )
                         {

--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -581,7 +581,7 @@ namespace Bulldozer.CSV
                     var rowGroupTypePurpose = row[GroupTypePurpose];
                     if ( !string.IsNullOrWhiteSpace( rowGroupTypePurpose ) )
                     {
-                        var purposeId = purposeTypeValues.Where( v => v.Value.Equals( rowGroupTypePurpose ) || v.Id.Equals( rowGroupTypePurpose ) || v.Guid.ToString().ToLower().Equals( rowGroupTypePurpose.ToLower() ) )
+                        var purposeId = purposeTypeValues.Where( v => v.Value.Equals( rowGroupTypePurpose ) || v.Id.Equals( rowGroupTypePurpose.AsInteger() ) || v.Guid.ToString().ToLower().Equals( rowGroupTypePurpose.ToLower() ) )
                                 .Select( v => ( int? ) v.Id ).FirstOrDefault();
 
                         newGroupType.GroupTypePurposeValueId = purposeId;

--- a/Bulldozer.CSV/SampleCSVs/06 - Contribution.csv
+++ b/Bulldozer.CSV/SampleCSVs/06 - Contribution.csv
@@ -1,4 +1,4 @@
-IndividualID,FundName,SubFundName,FundGLAccount,SubFundGLAcount,FundIsActive,SubFundIsActive,ReceivedDate,CheckNumber,Memo,ContributionTypeName,Amount,StatedValue,ContributionID,ContributionBatchID,ContributionCreditCardType,IsAnonymous,Gateway,ScheduledTransactionForeignKey,FundId,^Projects^Project^V
+IndividualID,FundName,SubFundName,FundGLAccount,SubFundGLAccount,FundIsActive,SubFundIsActive,ReceivedDate,CheckNumber,Memo,ContributionTypeName,Amount,StatedValue,ContributionID,ContributionBatchID,ContributionCreditCardType,IsAnonymous,Gateway,ScheduledTransactionForeignKey,FundId,^Projects^Project^V
 25570361,General Fund,,41000,,1,,2/7/2016,123,,Check,25,25,1,1,,,,,1,
 146,General Fund,,41000,,1,,2/7/2016,,,Cash,25,25,2,1,,,,,,
 25570361,General Fund,,41000,,1,,2/14/2016,125,,Check,125,125,3,2,,,,,,Share the Love

--- a/Bulldozer/Utility/Extensions.cs
+++ b/Bulldozer/Utility/Extensions.cs
@@ -167,8 +167,9 @@ namespace Bulldozer.Utility
                                       "MM/dd/yyyy hh:mm:ss", "M/d/yyyy h:mm:ss",
                                       "M/d/yyyy hh:mm tt", "M/d/yyyy hh tt",
                                       "M/d/yyyy h:mm", "M/d/yyyy h:mm",
-                                      "MM/dd/yyyy hh:mm", "M/dd/yyyy hh:mm",
-                                      "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm:ss.fff", "yyyy-MM-dd HH:mm:ss.fff tt" };
+                                      "MM/dd/yyyy hh:mm", "M/dd/yyyy hh:mm", "yyyy-MM-dd HH:mm:ss",
+                                      "yyyy-MM-dd HH:mm:ss.fff", "yyyy-MM-dd HH:mm:ss.ffff", "yyyy-MM-dd HH:mm:ss.fffff",
+                                      "yyyy-MM-dd HH:mm:ss.ffffff", "yyyy-MM-dd HH:mm:ss.fffffff", "yyyy-MM-dd HH:mm:ss.fff tt" };
 
             if ( DateTime.TryParseExact( stringValue, dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out parsed ) )
             {


### PR DESCRIPTION
### Description   
  
A few data handling issues were encountered and fixed.

##### What does the change add or fix?

- Fixed bug causing GroupTypePurpose values to not properly import when mapped by Id (Integer).  
- Fixed bug with metric partitions due to partition ordering and metric value dates.  
- Enhance Account "IsActive" and "IsTaxDeductible" bools to properly handle "Yes"/"No" values from input csv.  
- Added a few more date formats to be handled on attribute importing.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Fixed bug causing GroupTypePurpose values to not properly import when mapped by Id (Integer).  
- Fixed bug with metric partitions due to partition ordering and metric value dates.  
- Enhance Account "IsActive" and "IsTaxDeductible" bools to properly handle "Yes"/"No" values from input csv.  
- Added a few more date formats to be handled on attribute importing.

---------

### Requested By

##### Who reported, requested, or paid for the change?

KFS

---------

### Screenshots

##### Does this update or add options to the block UI?

NONE

---------

### Change Log

##### What files does it affect?

- Bulldozer.CSV/Maps/Financial.cs
- Bulldozer.CSV/Maps/Group.cs
- Bulldozer.CSV/Maps/Metrics.cs
- Bulldozer.CSV/SampleCSVs/06 - Contribution.csv
- Bulldozer/Utility/Extensions.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
