### PR TITLE
F1 mdf migration enhancements

### DIFF
--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -497,6 +497,7 @@ namespace Bulldozer.CSV
             var newGroupTypeList = new List<GroupType>();
             var purposeTypeValues = DefinedTypeCache.Get( new Guid( Rock.SystemGuid.DefinedType.GROUPTYPE_PURPOSE ), lookupContext ).DefinedValues;
             var locationMeetingId = DefinedValueCache.Get( new Guid( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_MEETING_LOCATION ), lookupContext ).Id;
+            var groupTypeService = new GroupTypeService( lookupContext );
 
             var numImportedGroupTypes = ImportedGroupTypes.Count();
             var completed = 0;
@@ -513,8 +514,8 @@ namespace Bulldozer.CSV
                 var groupTypeForeignId = rowGroupTypeKey.AsType<int?>();
 
                 // Check that this group type isn't already in our data
-                var groupTypeExists = false;
-                if ( numImportedGroupTypes > 0 )
+                var groupTypeExists = groupTypeService.Queryable().Any( t => t.ForeignKey == rowGroupTypeKey );
+                if ( !groupTypeExists && numImportedGroupTypes > 0 )
                 {
                     groupTypeExists = ImportedGroupTypes.Any( t => t.ForeignKey == rowGroupTypeKey );
                 }
@@ -522,7 +523,7 @@ namespace Bulldozer.CSV
                 // Check if this was an existing group type that needs foreign id added
                 if ( !groupTypeExists )
                 {
-                    var groupType = new GroupTypeService( lookupContext ).Queryable().FirstOrDefault( t => ( t.ForeignKey == null || t.ForeignKey.Trim() == "" ) && t.Name.Equals( rowGroupTypeName, StringComparison.OrdinalIgnoreCase ) );
+                    var groupType = groupTypeService.Queryable().FirstOrDefault( t => ( t.ForeignKey == null || t.ForeignKey.Trim() == "" ) && t.Name.Equals( rowGroupTypeName, StringComparison.OrdinalIgnoreCase ) );
                     if ( groupType != null )
                     {
                         groupType.ForeignKey = rowGroupTypeKey;

--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -497,7 +497,6 @@ namespace Bulldozer.CSV
             var newGroupTypeList = new List<GroupType>();
             var purposeTypeValues = DefinedTypeCache.Get( new Guid( Rock.SystemGuid.DefinedType.GROUPTYPE_PURPOSE ), lookupContext ).DefinedValues;
             var locationMeetingId = DefinedValueCache.Get( new Guid( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_MEETING_LOCATION ), lookupContext ).Id;
-            var groupTypeService = new GroupTypeService( lookupContext );
 
             var numImportedGroupTypes = ImportedGroupTypes.Count();
             var completed = 0;
@@ -514,8 +513,8 @@ namespace Bulldozer.CSV
                 var groupTypeForeignId = rowGroupTypeKey.AsType<int?>();
 
                 // Check that this group type isn't already in our data
-                var groupTypeExists = groupTypeService.Queryable().Any( t => t.ForeignKey == rowGroupTypeKey );
-                if ( !groupTypeExists && numImportedGroupTypes > 0 )
+                var groupTypeExists = false;
+                if ( numImportedGroupTypes > 0 )
                 {
                     groupTypeExists = ImportedGroupTypes.Any( t => t.ForeignKey == rowGroupTypeKey );
                 }
@@ -523,7 +522,7 @@ namespace Bulldozer.CSV
                 // Check if this was an existing group type that needs foreign id added
                 if ( !groupTypeExists )
                 {
-                    var groupType = groupTypeService.Queryable().FirstOrDefault( t => ( t.ForeignKey == null || t.ForeignKey.Trim() == "" ) && t.Name.Equals( rowGroupTypeName, StringComparison.OrdinalIgnoreCase ) );
+                    var groupType = new GroupTypeService( lookupContext ).Queryable().FirstOrDefault( t => ( t.ForeignKey == null || t.ForeignKey.Trim() == "" ) && t.Name.Equals( rowGroupTypeName, StringComparison.OrdinalIgnoreCase ) );
                     if ( groupType != null )
                     {
                         groupType.ForeignKey = rowGroupTypeKey;

--- a/Bulldozer.FellowshipOne/F1Component.cs
+++ b/Bulldozer.FellowshipOne/F1Component.cs
@@ -82,7 +82,7 @@ namespace Bulldozer.F1
         private Dictionary<int, int> PortalUsers;
 
         /// <summary>
-        /// All the group types that have been imported
+        /// All the groups that have been imported
         /// </summary>
         private List<Group> ImportedGroups;
 
@@ -100,6 +100,11 @@ namespace Bulldozer.F1
         /// All imported groups from "Has_Chekin" activity ministries
         /// </summary>
         private List<Group> ImportedCheckinActivityGroups;
+
+        /// <summary>
+        /// Top level Serving Team group
+        /// </summary>
+        protected Group ServingTeamsParentGroup;
 
         // Custom attribute types
 
@@ -252,8 +257,7 @@ namespace Bulldozer.F1
                             break;
 
                         case "Activity_Group":
-                            var hasActivitySchedule = tableList.Any( t => t.Name == "Activity_Schedule" );
-                            MapActivityGroup( scanner.ScanTable( table.Name ).AsQueryable(), totalRows, hasActivitySchedule ? scanner.ScanTable( "Activity_Schedule" ).AsQueryable() : null );
+                            MapActivityGroup( scanner.ScanTable( table.Name ).AsQueryable(), totalRows );
                             break;
 
                         case "Attendance":
@@ -471,6 +475,8 @@ namespace Bulldozer.F1
             ImportedBatches = new FinancialBatchService( lookupContext ).Queryable().AsNoTracking()
                 .Where( b => b.ForeignId.HasValue )
                 .ToDictionary( t => ( int ) t.ForeignId, t => ( int? ) t.Id );
+
+            ServingTeamsParentGroup = lookupContext.Groups.AsNoTracking().AsQueryable().FirstOrDefault( g => g.Guid.ToString() == "31730962-4C7B-425B-BD73-4185331F37EF" );
 
             // get the portal users for lookups on notes
             var userIdList = scanner.ScanTable( "Users" )

--- a/Bulldozer.FellowshipOne/F1Component.cs
+++ b/Bulldozer.FellowshipOne/F1Component.cs
@@ -97,7 +97,7 @@ namespace Bulldozer.F1
         protected static Dictionary<int, int?> ImportedBatches;
 
         /// <summary>
-        /// All imported groups from "Has_Chekin" activity ministries
+        /// All imported groups from "Has_Checkin" activity ministries
         /// </summary>
         private List<Group> ImportedCheckinActivityGroups;
 

--- a/Bulldozer.FellowshipOne/Maps/Attendance.cs
+++ b/Bulldozer.FellowshipOne/Maps/Attendance.cs
@@ -89,6 +89,17 @@ namespace Bulldozer.F1
                 var checkinDate = row["Check_In_Time"] as DateTime?;
                 var checkoutDate = row["Check_Out_Time"] as DateTime?;
                 var machineName = row["Checkin_Machine_Name"] as string;
+                var activityScheduleId = row["Activity_schedule_ID"] as int?;
+                var scheduleId = archivedSchedule.Id;
+
+                if ( activityScheduleId.HasValue && activityScheduleId.Value > 0 )
+                {
+                    var existingSchedule = lookupContext.Schedules.AsNoTracking().AsQueryable().FirstOrDefault( s => s.ForeignId == activityScheduleId );
+                    if ( existingSchedule != null )
+                    {
+                        scheduleId = existingSchedule.Id;
+                    }
+                }
 
                 // at minimum, attendance needs a person and a date
                 var personKeys = GetPersonKeys( individualId, null );
@@ -119,18 +130,18 @@ namespace Bulldozer.F1
                     }
 
                     // occurrence is required for attendance
-                    int? occurrenceId = existingOccurrences.GetValueOrNull( $"{rockGroupId}|{locationId}|{archivedSchedule.Id}|{startDateString}" );
+                    int? occurrenceId = existingOccurrences.GetValueOrNull( $"{rockGroupId}|{locationId}|{scheduleId}|{startDateString}" );
                     if ( occurrenceId.HasValue )
                     {
                         attendance.OccurrenceId = occurrenceId.Value;
                     }
                     else
                     {
-                        var newOccurrence = AddOccurrence( null, ( DateTime ) startDate, rockGroupId, archivedSchedule.Id, locationId, true );
+                        var newOccurrence = AddOccurrence( null, ( DateTime ) startDate, rockGroupId, scheduleId, locationId, true );
                         if ( newOccurrence != null )
                         {
                             attendance.OccurrenceId = newOccurrence.Id;
-                            existingOccurrences.Add( $"{rockGroupId}|{locationId}|{archivedSchedule.Id}|{startDateString}", newOccurrence.Id );
+                            existingOccurrences.Add( $"{rockGroupId}|{locationId}|{scheduleId}|{startDateString}", newOccurrence.Id );
                         }
                     }
 
@@ -252,6 +263,14 @@ namespace Bulldozer.F1
                 var checkinDate = row["CheckinDateTime"] as DateTime?;
                 var checkoutDate = row["CheckoutDateTime"] as DateTime?;
                 var createdDate = row["AttendanceCreatedDate"] as DateTime?;
+                var scheduleForeignKey = "F1GD_" + groupId.Value.ToString();
+                var scheduleId = archivedSchedule.Id;
+
+                var existingSchedule = lookupContext.Schedules.AsNoTracking().AsQueryable().FirstOrDefault( s => s.ForeignKey == scheduleForeignKey );
+                if ( existingSchedule != null )
+                {
+                    scheduleId = existingSchedule.Id;
+                }
 
                 var personKeys = GetPersonKeys( individualId, null );
                 if ( personKeys != null && personKeys.PersonAliasId > 0 && startDate.HasValue )
@@ -281,18 +300,18 @@ namespace Bulldozer.F1
                     }
 
                     // occurrence is required for attendance
-                    int? occurrenceId = existingOccurrences.GetValueOrNull( $"{rockGroupId}|{locationId}|{archivedSchedule.Id}|{startDateString}" );
+                    int? occurrenceId = existingOccurrences.GetValueOrNull( $"{rockGroupId}|{locationId}|{scheduleId}|{startDateString}" );
                     if ( occurrenceId.HasValue )
                     {
                         attendance.OccurrenceId = occurrenceId.Value;
                     }
                     else
                     {
-                        var newOccurrence = AddOccurrence( null, ( DateTime ) startDate, rockGroupId, archivedSchedule.Id, locationId, true );
+                        var newOccurrence = AddOccurrence( null, ( DateTime ) startDate, rockGroupId, scheduleId, locationId, true );
                         if ( newOccurrence != null )
                         {
                             attendance.OccurrenceId = newOccurrence.Id;
-                            existingOccurrences.Add( $"{rockGroupId}|{locationId}|{archivedSchedule.Id}|{startDateString}", newOccurrence.Id );
+                            existingOccurrences.Add( $"{rockGroupId}|{locationId}|{scheduleId}|{startDateString}", newOccurrence.Id );
                         }
                     }
 

--- a/Bulldozer.FellowshipOne/Maps/Attendance.cs
+++ b/Bulldozer.FellowshipOne/Maps/Attendance.cs
@@ -94,10 +94,10 @@ namespace Bulldozer.F1
 
                 if ( activityScheduleId.HasValue && activityScheduleId.Value > 0 )
                 {
-                    var existingSchedule = lookupContext.Schedules.AsNoTracking().AsQueryable().FirstOrDefault( s => s.ForeignId == activityScheduleId );
-                    if ( existingSchedule != null )
+                    int? existingScheduleId = lookupContext.Schedules.AsNoTracking().AsQueryable().Where( s => s.ForeignId == activityScheduleId ).Select( s => s.Id ).FirstOrDefault();
+                    if ( existingScheduleId.HasValue && existingScheduleId.Value > 0 )
                     {
-                        scheduleId = existingSchedule.Id;
+                        scheduleId = existingScheduleId.Value;
                     }
                 }
 

--- a/Bulldozer.FellowshipOne/Maps/Communication.cs
+++ b/Bulldozer.FellowshipOne/Maps/Communication.cs
@@ -206,10 +206,23 @@ namespace Bulldozer.F1
                                         person.EmailNote = communicationComment;
                                         lookupContext.SaveChanges( DisableAuditing );
                                     }
-                                    // this is a different email, assign it to SecondaryEmail
-                                    else if ( !person.Email.Equals( value ) && !person.Attributes.ContainsKey( SecondaryEmailAttribute.Key ) )
+                                    // this is a different email, add as PersonSearchKey
+                                    else if ( !person.Email.Equals( value )  )
                                     {
-                                        AddEntityAttributeValue( lookupContext, SecondaryEmailAttribute, person, value );
+                                        // add email as PersonSearchKey
+                                        int emailValueId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.PERSON_SEARCH_KEYS_EMAIL.AsGuid() ).Id;
+                                        if ( !person.GetPersonSearchKeys().Any( k => k.SearchTypeValueId == emailValueId && k.SearchValue == value ) )
+                                        {
+                                            lookupContext.PersonSearchKeys.Add( new PersonSearchKey()
+                                            {
+                                                PersonAlias = person.Aliases.First(),
+                                                SearchTypeValueId = emailValueId,
+                                                SearchValue = value,
+                                                ForeignKey = communicationId.ToString(),
+                                                ForeignId = communicationId
+                                            } );
+                                            lookupContext.SaveChanges( DisableAuditing );
+                                        }
                                     }
                                 }
                                 else if ( type.Contains( "Twitter" ) && !person.Attributes.ContainsKey( twitterAttribute.Key ) )

--- a/Bulldozer.FellowshipOne/Maps/Communication.cs
+++ b/Bulldozer.FellowshipOne/Maps/Communication.cs
@@ -71,6 +71,7 @@ namespace Bulldozer.F1
             {
                 foreach ( var row in groupedRows.Where( r => r != null ) )
                 {
+                    var communicationId = row["Communication_ID"] as int?;
                     var value = row["Communication_Value"] as string;
                     var individualId = row["Individual_ID"] as int?;
                     var householdId = row["Household_ID"] as int?;
@@ -137,8 +138,7 @@ namespace Bulldozer.F1
                                             phoneTypeId = newPhoneType.Id;
                                         }
                                     }
-
-                                    var numberExists = existingNumbers.Any( n => n.PersonId == personKeys.PersonId && n.Number.Equals( normalizedNumber ) && n.NumberTypeValueId == phoneTypeId );
+                                    var numberExists = existingNumbers.Any( n => ( communicationId != null && ( n.ForeignKey == communicationId.ToString() || n.ForeignId == communicationId ) ) || ( n.PersonId == personKeys.PersonId && n.Number.Equals( normalizedNumber ) && n.NumberTypeValueId == phoneTypeId ) );
                                     if ( !numberExists )
                                     {
                                         var numberOnly = normalizedNumber.Left( 20 );

--- a/Bulldozer.FellowshipOne/Maps/Communication.cs
+++ b/Bulldozer.FellowshipOne/Maps/Communication.cs
@@ -105,11 +105,11 @@ namespace Bulldozer.F1
                             var normalizedNumber = string.Empty;
                             var countryIndex = value.IndexOf( '+' );
                             var extensionIndex = value.LastIndexOf( 'x' ) > 0 ? value.LastIndexOf( 'x' ) : value.Length;
-                            if ( countryIndex >= 0 )
+                            if ( countryIndex == 0 )
                             {
                                 countryCode = value.Substring( countryIndex, countryIndex + 3 ).AsNumeric();
                                 normalizedNumber = value.Substring( countryIndex + 3, extensionIndex - 3 ).AsNumeric();
-                                extension = value.Substring( extensionIndex );
+                                extension = value.Substring( extensionIndex ).AsNumeric();
                             }
                             else if ( extensionIndex > 0 )
                             {
@@ -141,18 +141,23 @@ namespace Bulldozer.F1
                                     var numberExists = existingNumbers.Any( n => n.PersonId == personKeys.PersonId && n.Number.Equals( normalizedNumber ) && n.NumberTypeValueId == phoneTypeId );
                                     if ( !numberExists )
                                     {
-                                        var newNumber = new PhoneNumber();
-                                        newNumber.CreatedByPersonAliasId = ImportPersonAliasId;
-                                        newNumber.ModifiedDateTime = lastUpdated;
-                                        newNumber.PersonId = ( int ) personKeys.PersonId;
-                                        newNumber.IsMessagingEnabled = type.StartsWith( "Mobile", StringComparison.OrdinalIgnoreCase );
-                                        newNumber.CountryCode = countryCode;
-                                        newNumber.IsUnlisted = !isListed;
-                                        newNumber.Extension = extension.Left( 20 ) ?? string.Empty;
-                                        newNumber.Number = normalizedNumber.Left( 20 );
-                                        newNumber.Description = communicationComment;
-                                        newNumber.NumberFormatted = PhoneNumber.FormattedNumber( countryCode, newNumber.Number, true );
-                                        newNumber.NumberTypeValueId = phoneTypeId;
+                                        var numberOnly = normalizedNumber.Left( 20 );
+                                        var newNumber = new PhoneNumber
+                                        {
+                                            CreatedByPersonAliasId = ImportPersonAliasId,
+                                            ModifiedDateTime = lastUpdated,
+                                            PersonId = ( int ) personKeys.PersonId,
+                                            IsMessagingEnabled = type.StartsWith( "Mobile", StringComparison.OrdinalIgnoreCase ),
+                                            CountryCode = countryCode,
+                                            IsUnlisted = !isListed,
+                                            Extension = extension.Left( 20 ) ?? string.Empty,
+                                            Number = numberOnly,
+                                            Description = communicationComment,
+                                            NumberFormatted = PhoneNumber.FormattedNumber( countryCode, numberOnly, true ),
+                                            NumberTypeValueId = phoneTypeId,
+                                            ForeignKey = communicationId.ToString(),
+                                            ForeignId = communicationId
+                                        };
 
                                         newNumbers.Add( newNumber );
                                         existingNumbers.Add( newNumber );

--- a/Bulldozer.FellowshipOne/Maps/Financial.cs
+++ b/Bulldozer.FellowshipOne/Maps/Financial.cs
@@ -433,7 +433,7 @@ namespace Bulldozer.F1
                         if ( parentAccount == null )
                         {
                             int? accountTypeDefinedTypeId = null;
-                            if ( !string.IsNullOrWhiteSpace ( fundType ) )
+                            if ( !string.IsNullOrWhiteSpace( fundType ) )
                             {
                                 accountTypeDefinedTypeId = LoadAccountTypeDefinedValue( lookupContext, fundType );
                             }
@@ -684,12 +684,12 @@ namespace Bulldozer.F1
             //
             // Add the defined value if it doesn't exist.
             //
-            int? definedValueId = rockContext.DefinedValues.Where( v => v.DefinedTypeId == FinancialAccountTypeDefindedTypeId && v.Value.Equals( value ) ).Select( v => v.Id ).FirstOrDefault();
+            int? definedValueId = rockContext.DefinedValues.Where( v => v.DefinedTypeId == FinancialAccountTypeDefinedTypeId && v.Value.Equals( value ) ).Select( v => v.Id ).FirstOrDefault();
             if ( !definedValueId.HasValue || definedValueId.Value < 1 )
             {
                 var newDefinedValue = new DefinedValue
                 {
-                    DefinedTypeId = FinancialAccountTypeDefindedTypeId,
+                    DefinedTypeId = FinancialAccountTypeDefinedTypeId,
                     Value = value,
                     Order = 0
                 };

--- a/Bulldozer.FellowshipOne/Maps/Financial.cs
+++ b/Bulldozer.FellowshipOne/Maps/Financial.cs
@@ -460,7 +460,7 @@ namespace Bulldozer.F1
                             if ( childAccount == null )
                             {
                                 // create a child account with a campusId if it was set
-                                childAccount = AddFinancialAccount( lookupContext, subFund, $"{subFund} imported {ImportDateTime}", subFundGLAccount, campusFundId, parentAccount.Id, isFundActive.AsBooleanOrNull(), receivedDate, subFund.RemoveSpecialCharacters() );
+                                childAccount = AddFinancialAccount( lookupContext, subFund, $"{subFund} imported {ImportDateTime}", subFundGLAccount, campusFundId, parentAccount.Id, isFundActive.AsBooleanOrNull(), receivedDate, subFund.RemoveSpecialCharacters(), accountTypeValueId: parentAccount.AccountTypeValueId );
                                 accountList.Add( childAccount );
                             }
 
@@ -629,7 +629,7 @@ namespace Bulldozer.F1
                                 if ( childAccount == null )
                                 {
                                     // create a child account with a campusId if it was set
-                                    childAccount = AddFinancialAccount( lookupContext, subFund, $"{subFund} imported {ImportDateTime}", string.Empty, campusFundId, parentAccount.Id, null, startDate, subFund.RemoveSpecialCharacters() );
+                                    childAccount = AddFinancialAccount( lookupContext, subFund, $"{subFund} imported {ImportDateTime}", string.Empty, campusFundId, parentAccount.Id, null, startDate, subFund.RemoveSpecialCharacters(), accountTypeValueId: parentAccount.AccountTypeValueId );
                                     accountList.Add( childAccount );
                                 }
 

--- a/Bulldozer.FellowshipOne/Maps/Financial.cs
+++ b/Bulldozer.FellowshipOne/Maps/Financial.cs
@@ -419,6 +419,7 @@ namespace Bulldozer.F1
                     }
 
                     var fundName = contributionFields.Contains( "Fund_Name" ) ? row["Fund_Name"] as string : string.Empty;
+                    var fundType = contributionFields.Contains( "Fund_type" ) ? row["Fund_type"] as string : string.Empty;
                     var subFund = contributionFields.Contains( "Sub_Fund_Name" ) ? row["Sub_Fund_Name"] as string : string.Empty;
                     var fundGLAccount = contributionFields.Contains( "Fund_GL_Account" ) ? row["Fund_GL_Account"] as string : string.Empty;
                     var subFundGLAccount = contributionFields.Contains( "Sub_Fund_GL_Account" ) ? row["Sub_Fund_GL_Account"] as string : string.Empty;
@@ -431,7 +432,12 @@ namespace Bulldozer.F1
                         var parentAccount = accountList.FirstOrDefault( a => !a.CampusId.HasValue && a.Name.Equals( fundName.Truncate( 50 ), StringComparison.OrdinalIgnoreCase ) );
                         if ( parentAccount == null )
                         {
-                            parentAccount = AddFinancialAccount( lookupContext, fundName, $"{fundName} imported {ImportDateTime}", fundGLAccount, null, null, isFundActive.AsBooleanOrNull(), receivedDate, fundName.RemoveSpecialCharacters() );
+                            int? accountTypeDefinedTypeId = null;
+                            if ( !string.IsNullOrWhiteSpace ( fundType ) )
+                            {
+                                accountTypeDefinedTypeId = LoadAccountTypeDefinedValue( lookupContext, fundType );
+                            }
+                            parentAccount = AddFinancialAccount( lookupContext, fundName, $"{fundName} imported {ImportDateTime}", fundGLAccount, null, null, isFundActive.AsBooleanOrNull(), receivedDate, fundName.RemoveSpecialCharacters(), accountTypeValueId: accountTypeDefinedTypeId );
                             accountList.Add( parentAccount );
                         }
 
@@ -671,6 +677,30 @@ namespace Bulldozer.F1
             {
                 rockContext.BulkInsert( newPledges );
             }
+        }
+
+        private int? LoadAccountTypeDefinedValue( RockContext rockContext, string value )
+        {
+            //
+            // Add the defined value if it doesn't exist.
+            //
+            int? definedValueId = rockContext.DefinedValues.Where( v => v.DefinedTypeId == FinancialAccountTypeDefindedTypeId && v.Value.Equals( value ) ).Select( v => v.Id ).FirstOrDefault();
+            if ( !definedValueId.HasValue || definedValueId.Value < 1 )
+            {
+                var newDefinedValue = new DefinedValue
+                {
+                    DefinedTypeId = FinancialAccountTypeDefindedTypeId,
+                    Value = value,
+                    Order = 0
+                };
+
+                rockContext.DefinedValues.Add( newDefinedValue );
+                rockContext.SaveChanges( DisableAuditing );
+
+                definedValueId = newDefinedValue.Id;
+            }
+
+            return definedValueId;
         }
     }
 }

--- a/Bulldozer.FellowshipOne/Maps/Groups.cs
+++ b/Bulldozer.FellowshipOne/Maps/Groups.cs
@@ -1222,10 +1222,15 @@ namespace Bulldozer.F1
                 var startHour = row["StartHour"] as string;
                 var groupId = row["Group_ID"] as int?;
                 var scheduleForeignKey = "F1GD_" + groupId.Value.ToString();
-                int? startTime = null;
+                DateTime? startTime = null;
+                DateTime startTimeWorker;
                 if ( !string.IsNullOrWhiteSpace( startHour ) )
                 {
-                    startTime = startHour.AsIntegerOrNull();
+                    startHour += ":00";   // StartHour comes in with HH:mm format. Add 00 seconds for full time format
+                    if ( DateTime.TryParse( startHour, out startTimeWorker ) )
+                    {
+                        startTime = startTimeWorker;
+                    }
                 }
 
                 // Only pull in valid schedules with RecurrenceType of weekly
@@ -1238,10 +1243,9 @@ namespace Bulldozer.F1
                         if ( Enum.TryParse( scheduleDay.Trim(), true, out dayEnum ) )
                         {
                             var day = dayEnum;
-                            var time = new DateTime( 1900, 1, 1, startTime.Value, 0, 0 );
 
                             // don't save immediately, we'll batch add later
-                            currentSchedule = AddNamedSchedule( lookupContext, string.Empty, string.Empty, day, time, null, scheduleForeignKey, instantSave: false, creatorPersonAliasId: ImportPersonAliasId );
+                            currentSchedule = AddNamedSchedule( lookupContext, string.Empty, string.Empty, day, startTime, null, scheduleForeignKey, instantSave: false, creatorPersonAliasId: ImportPersonAliasId );
                             newSchedules.Add( currentSchedule );
                         }
                     }

--- a/Bulldozer.FellowshipOne/Maps/Groups.cs
+++ b/Bulldozer.FellowshipOne/Maps/Groups.cs
@@ -415,6 +415,14 @@ namespace Bulldozer.F1
                 var individualId = row["Individual_ID"] as int?;
                 var groupCreated = row["Created_Date"] as DateTime?;
                 var groupType = row["Group_Type_Name"] as string;
+                string campusName = null;
+                try
+                {
+                    campusName = row["CampusName"] as string;
+                }
+                catch
+                {
+                } 
 
                 // require at least a group id and name
                 if ( groupId.HasValue && !string.IsNullOrWhiteSpace( groupName ) && !groupName.Equals( "Delete", StringComparison.OrdinalIgnoreCase ) )
@@ -458,7 +466,7 @@ namespace Bulldozer.F1
                         }
 
                         // put the current group under a campus parent if it exists
-                        campusId = campusId ?? GetCampusId( groupName );
+                        campusId = campusId ?? GetCampusId( groupName, possibleCampusName: campusName );
                         if ( campusId.HasValue )
                         {
                             // create a campus level parent for the home group

--- a/Bulldozer.FellowshipOne/Maps/People.cs
+++ b/Bulldozer.FellowshipOne/Maps/People.cs
@@ -243,8 +243,6 @@ namespace Bulldozer.F1
             var positionAttribute = personAttributes.FirstOrDefault( a => a.Key.Equals( "Position", StringComparison.OrdinalIgnoreCase ) );
             var schoolAttribute = personAttributes.FirstOrDefault( a => a.Key.Equals( "School", StringComparison.OrdinalIgnoreCase ) );
             var envelopeNumberAttribute = personAttributes.FirstOrDefault( a => a.Guid.ToString().Equals( Rock.SystemGuid.Attribute.PERSON_GIVING_ENVELOPE_NUMBER, StringComparison.OrdinalIgnoreCase ) );
-            var barcodeAttribute = AddEntityAttribute( lookupContext, PersonEntityTypeId, string.Empty, string.Empty, string.Empty, string.Empty,
-                "Personal Barcode", "PersonalBarcode", TextFieldTypeId, true );
 
             var familyList = new List<Group>();
             var visitorList = new List<Group>();

--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -211,7 +211,7 @@ namespace Bulldozer.Utility
         /// <param name="creatorPersonAliasId">The creator person alias identifier.</param>
         /// <returns></returns>
         public static FinancialAccount AddFinancialAccount( RockContext rockContext, string fundName, string fundDescription, string accountGL, int? fundCampusId,
-            int? parentAccountId, bool? isActive, DateTime? dateCreated, string accountForeignKey, bool instantSave = true, int? creatorPersonAliasId = null )
+            int? parentAccountId, bool? isActive, DateTime? dateCreated, string accountForeignKey, bool instantSave = true, int? creatorPersonAliasId = null, int? accountTypeValueId = null )
         {
             rockContext = rockContext ?? new RockContext();
 
@@ -230,7 +230,8 @@ namespace Bulldozer.Utility
                 CreatedDateTime = dateCreated,
                 CreatedByPersonAliasId = creatorPersonAliasId,
                 ForeignKey = accountForeignKey,
-                ForeignId = accountForeignKey.AsIntegerOrNull()
+                ForeignId = accountForeignKey.AsIntegerOrNull(),
+                AccountTypeValueId = accountTypeValueId
             };
 
             if ( instantSave )

--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -328,20 +328,20 @@ namespace Bulldozer.Utility
         }
 
         /// <summary>
-        /// Builds out a Serving Group heirarchy based off the heirarchy of a specific group.
+        /// Builds out a Serving Group hierarchy based off the hierarchy of a specific group.
         /// </summary>
         /// <param name="rockContext">todo: describe rockContext parameter on AddGroup</param>
         /// <param name="topLevelServingGroup">The the top level serving group to build the group struture under.</param>
-        /// <param name="nonServingParentGroup">The parent group to copy from and use for cloning its heirarchy.</param>
+        /// <param name="nonServingParentGroup">The parent group to copy from and use for cloning its hierarchy.</param>
         /// <param name="copyCampus">Should the campus of the nonServingParentGroup be copied to the new group structure?.</param>
         /// <param name="creatorPersonAliasId">todo: describe creatorPersonAliasId parameter on AddGroup</param>
         /// <returns></returns>
-        public static List<Group> BuildParentServingGroupHeirarchy( RockContext rockContext, Group topLevelServingGroup, Group nonServingParentGroup, bool copyCampus = false, int? creatorPersonAliasId = null )
+        public static List<Group> BuildParentServingGroupHierarchy( RockContext rockContext, Group topLevelServingGroup, Group nonServingParentGroup, bool copyCampus = false, int? creatorPersonAliasId = null )
         {
             var groupHeirarchyToCopy = GetGroupHeirarchyAscending( nonServingParentGroup );
             var parentServingGroup = topLevelServingGroup;
             var newGroups = new List<Group>();
-            foreach ( var group in groupHeirarchyToCopy )
+            foreach ( var group in groupHierarchyToCopy )
             {
                 // Create the matching Serving group type if doesn't exist yet
                 var childGroupType = rockContext.GroupTypes.AsNoTracking().AsQueryable().Where( t => t.Id == group.GroupTypeId ).ToDictionary( t => t.ForeignKey, t => t.Name ).FirstOrDefault();
@@ -377,23 +377,23 @@ namespace Bulldozer.Utility
         }
 
         /// <summary>
-        /// Recursive method to gather all the groups in a specific group's heirarchy from the bottom up.
+        /// Recursive method to gather all the groups in a specific group's hierarchy from the bottom up.
         /// </summary>
         /// <param name="childGroup">Child Group to build up from.</param>
-        /// <param name="groupHeirarchy">Running list of groups to handle recursion.</param>
+        /// <param name="groupHierarchy">Running list of groups to handle recursion.</param>
         /// <returns></returns>
         public static List<Group> GetGroupHeirarchyAscending ( Group childGroup, List<Group> groupHeirarchy = null )
         {
-            if ( groupHeirarchy == null )
+            if ( groupHierarchy == null )
             {
-                groupHeirarchy = new List<Group>();
+                groupHierarchy = new List<Group>();
             }
-            groupHeirarchy.Insert( 0, childGroup );
             if ( childGroup.ParentGroup != null && childGroup.ParentGroup.ForeignKey != "ArchivedGroups" )
+            groupHierarchy.Insert( 0, childGroup );
             {
                 GetGroupHeirarchyAscending( childGroup.ParentGroup, groupHeirarchy );
             }
-            return groupHeirarchy;
+            return groupHierarchy;
         }
 
         /// <summary>

--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -415,9 +415,10 @@ namespace Bulldozer.Utility
         /// <param name="scheduleForeignKey">The schedule foreign key.</param>
         /// <param name="instantSave">if set to <c>true</c> [instant save].</param>
         /// <param name="creatorPersonAliasId">The creator person alias identifier.</param>
+        /// <param name="isActive">The active status of the schedule.</param>
         /// <returns></returns>
         public static Schedule AddNamedSchedule( RockContext rockContext, string scheduleName, string iCalendarContent, DayOfWeek? dayOfWeek,
-            DateTime? timeOfDay, DateTime? dateCreated, string scheduleForeignKey, bool instantSave = true, int? creatorPersonAliasId = null )
+            DateTime? timeOfDay, DateTime? dateCreated, string scheduleForeignKey, bool instantSave = true, int? creatorPersonAliasId = null, bool isActive = true )
         {
             var newSchedule = new Schedule
             {
@@ -429,7 +430,8 @@ namespace Bulldozer.Utility
                 CreatedDateTime = dateCreated,
                 ForeignKey = scheduleForeignKey,
                 ForeignId = scheduleForeignKey.AsIntegerOrNull(),
-                CreatedByPersonAliasId = creatorPersonAliasId
+                CreatedByPersonAliasId = creatorPersonAliasId, 
+                IsActive = isActive
             };
 
             if ( instantSave )

--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -1570,10 +1570,19 @@ namespace Bulldozer.Utility
         /// <param name="includeCampusName">if set to <c>true</c> [include campus name].</param>
         /// <param name="direction">The direction, default is begins with.</param>
         /// <returns></returns>
-        public static int? GetCampusId( string property, bool includeCampusName = true, SearchDirection direction = SearchDirection.Begins )
+        public static int? GetCampusId( string property, bool includeCampusName = true, SearchDirection direction = SearchDirection.Begins, string possibleCampusName = null )
         {
             int? campusId = null;
-            if ( !string.IsNullOrWhiteSpace( property ) )
+            if ( !string.IsNullOrWhiteSpace( possibleCampusName ) )
+            {
+                var campus = CampusList.AsQueryable().FirstOrDefault( c => c.ShortCode == possibleCampusName
+                        || ( includeCampusName && c.Name == possibleCampusName ) );
+                if ( campus != null )
+                {
+                    campusId = campus.Id;
+                }
+            }
+            if ( campusId == null && !string.IsNullOrWhiteSpace( property ) )
             {
                 var queryable = CampusList.AsQueryable();
 

--- a/Bulldozer/Utility/CachedTypes.cs
+++ b/Bulldozer/Utility/CachedTypes.cs
@@ -72,11 +72,11 @@ namespace Bulldozer.Utility
         public static int FamilyGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid() ).Id;
         public static int GeneralGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_GENERAL.AsGuid() ).Id;
         public static int SmallGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_SMALL_GROUP.AsGuid() ).Id;
-        public static int ServingTeamGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_SERVING_TEAM.AsGuid() ).Id;
         public static int CheckinGroupTypeId = GroupTypeCache.Get( "6E7AD783-7614-4721-ABC1-35842113EF59".AsGuid() ).Id;    // Check In group type
 
         public static GroupTypeCache KnownRelationshipGroupType = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_KNOWN_RELATIONSHIPS );
         public static GroupTypeCache ImpliedRelationshipGroupType = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_PEER_NETWORK );
+        public static GroupTypeCache ServingTeamGroupType = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_SERVING_TEAM.AsGuid() );
 
         // Group Location Types
 

--- a/Bulldozer/Utility/CachedTypes.cs
+++ b/Bulldozer/Utility/CachedTypes.cs
@@ -116,6 +116,8 @@ namespace Bulldozer.Utility
         public static int BenevolenceDeniedStatusId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.BENEVOLENCE_DENIED.AsGuid() ).Id;
         public static int BenevolencePendingStatusId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.BENEVOLENCE_PENDING.AsGuid() ).Id;
 
+        public static int FinancialAccountTypeDefindedTypeId = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.FINANCIAL_ACCOUNT_TYPE.AsGuid() ).Id;
+
         // Campus Types
 
         public static List<CampusCache> CampusList = CampusCache.All();

--- a/Bulldozer/Utility/CachedTypes.cs
+++ b/Bulldozer/Utility/CachedTypes.cs
@@ -72,6 +72,8 @@ namespace Bulldozer.Utility
         public static int FamilyGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_FAMILY.AsGuid() ).Id;
         public static int GeneralGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_GENERAL.AsGuid() ).Id;
         public static int SmallGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_SMALL_GROUP.AsGuid() ).Id;
+        public static int ServingTeamGroupTypeId = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_SERVING_TEAM.AsGuid() ).Id;
+        public static int CheckinGroupTypeId = GroupTypeCache.Get( "6E7AD783-7614-4721-ABC1-35842113EF59".AsGuid() ).Id;    // Check In group type
 
         public static GroupTypeCache KnownRelationshipGroupType = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_KNOWN_RELATIONSHIPS );
         public static GroupTypeCache ImpliedRelationshipGroupType = GroupTypeCache.Get( Rock.SystemGuid.GroupType.GROUPTYPE_PEER_NETWORK );
@@ -110,6 +112,7 @@ namespace Bulldozer.Utility
 
         public static int GroupTypeMeetingLocationId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_MEETING_LOCATION.AsGuid() ).Id;
         public static int GroupTypeCheckinTemplateId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.GROUPTYPE_PURPOSE_CHECKIN_TEMPLATE.AsGuid() ).Id;
+        public static int GroupTypePurposeServingAreaId = DefinedValueCache.Get( "36A554CE-7815-41B9-A435-93F3D52A2828".AsGuid() ).Id;      // Serving Area defined value for group type purpose
         public static int DeviceTypeCheckinKioskId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.DEVICE_TYPE_CHECKIN_KIOSK.AsGuid() ).Id;
 
         public static int BenevolenceApprovedStatusId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.BENEVOLENCE_APPROVED.AsGuid() ).Id;

--- a/Bulldozer/Utility/CachedTypes.cs
+++ b/Bulldozer/Utility/CachedTypes.cs
@@ -119,7 +119,7 @@ namespace Bulldozer.Utility
         public static int BenevolenceDeniedStatusId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.BENEVOLENCE_DENIED.AsGuid() ).Id;
         public static int BenevolencePendingStatusId = DefinedValueCache.Get( Rock.SystemGuid.DefinedValue.BENEVOLENCE_PENDING.AsGuid() ).Id;
 
-        public static int FinancialAccountTypeDefindedTypeId = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.FINANCIAL_ACCOUNT_TYPE.AsGuid() ).Id;
+        public static int FinancialAccountTypeDefinedTypeId = DefinedTypeCache.Get( Rock.SystemGuid.DefinedType.FINANCIAL_ACCOUNT_TYPE.AsGuid() ).Id;
 
         // Campus Types
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

* Enhanced phone number import logic to work around scenarios of bad strings causing exceptions.
* Added support for importing historical schedules for ActivityGroups and Groups from F1. Only "weekly" schedules are imported, and only schedules that are not check-in related and not serving group related. Group schedules are imported from the GroupsDescription table. Activity Group schedules must have the string "weekly" somewhere in the schedule name to be imported.
* Updated barcode importing to migrate person barcodes as Alternate Ids in Rock rather than person attributes.
* Added feature to migrate groups as Serving Team groups. Placing the string "SERV:" in the name of a Ministry, Activity, Roster Folder, Roster or Group will cause that entity to be migrated into the Serving Team Group structure. Any entity with that string will propagate down to every child entity under it. For instance, putting the string in a Ministry name will cause Bulldozer to import all Activities, Roster Folders and Rosters under that ministry into the Serving Team structure regardless of them having the string in their own name.
* Added support for migrating fund types from F1.

**New Settings:**

none

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Enhanced phone number import logic to work around scenarios of bad strings causing exceptions.
* Added support for importing historical schedules for ActivityGroups and Groups from F1. Only "weekly" schedules are imported, and only schedules that are not check-in related and not serving group related. Group schedules are imported from the GroupsDescription table. Activity Group schedules must have the string "weekly" somewhere in the schedule name to be imported.
* Updated barcode importing to migrate person barcodes as Alternate Ids in Rock rather than person attributes.
* Added feature to migrate groups as Serving Team groups. Placing the string "SERV:" in the name of a Ministry, Activity, Roster Folder, Roster or Group will cause that entity to be migrated into the Serving Team Group structure. Any entity with that string will propagate down to every child entity under it. For instance, putting the string in a Ministry name will cause Bulldozer to import all Activities, Roster Folders and Rosters under that ministry into the Serving Team structure regardless of them having the string in their own name.
* Added support for migrating fund types from F1.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Crossings Community Church

---------

### Screenshots

##### Does this update or add options to the block UI?
  
no

---------

### Change Log

##### What files does it affect?

* Bulldozer.FellowshipOne/F1Component.cs
* Bulldozer.FellowshipOne/Maps/Attendance.cs
* Bulldozer.FellowshipOne/Maps/Communication.cs
* Bulldozer.FellowshipOne/Maps/Financial.cs
* Bulldozer.FellowshipOne/Maps/Groups.cs
* Bulldozer.FellowshipOne/Maps/People.cs
* Bulldozer/Utility/AddMethods.cs
* Bulldozer/Utility/CachedTypes.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
