### PR TITLE
Fix null handling for GroupsAttendance import protection

### DIFF
--- a/Bulldozer.FellowshipOne/Maps/Attendance.cs
+++ b/Bulldozer.FellowshipOne/Maps/Attendance.cs
@@ -256,7 +256,7 @@ namespace Bulldozer.F1
             var percentage = ( totalRows - 1 ) / 100 + 1;
             ReportProgress( 0, $"Verifying group attendance import, ({totalRows:N0} found, {importedAttendancesCount:N0} already exist)." );
 
-            foreach ( var row in tableData.Where( r => r != null ) )
+            foreach ( var row in tableData.Where( r => r != null && r["GroupID"] != null && r["IndividualID"] != null ) )
             {
                 var groupId = row["GroupID"] as int?;
                 var startDate = row["StartDateTime"] as DateTime?;


### PR DESCRIPTION
### Description 

##### What does the change add or fix?
  
* Add additional null check for GroupsAttendance import protection

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Add additional null check for GroupsAttendance import protection

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

 * Bulldozer.FellowshipOne/Maps/Attendance.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
