### PR TITLE
Add logic to better handle invalid attendance locations

### DIFF
--- a/Bulldozer.CSV/Maps/Attendance.cs
+++ b/Bulldozer.CSV/Maps/Attendance.cs
@@ -112,8 +112,11 @@ namespace Bulldozer.CSV
                 if ( !string.IsNullOrEmpty( rowLocationKey ) )
                 {
                     location = locationService.Queryable().FirstOrDefault( l => l.ForeignKey == rowLocationKey );
-                    locationId = location.Id;
-                    campusId = location.CampusId;
+                    if ( location != null )
+                    {
+                        locationId = location.Id;
+                        campusId = location.CampusId;
+                    }
                 }
 
                 if ( alreadyImportedCount > 0 )


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Bulldozer would throw an exception and error out during attendance processing if the attendance record had a value provided for Location that does not match a valid imported location. This fix causes bulldozer to simply skip trying to make the location connection and continue processing the attendance for the offending record in this situation.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Added logic to handle bad location data in Attendance import file more gracefully.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

none

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/Maps/Attendance.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
