### PR TITLE
CSV Individual Import - Previous Person Ids

### DIFF
--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -668,6 +668,7 @@ namespace Bulldozer.CSV
         private const int GeneralNote = 27;
         private const int MedicalNote = 28;
         private const int SecurityNote = 29;
+        private const int PreviousPersonIds = 30;
 
         #endregion Individual Constants
 

--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -669,6 +669,7 @@ namespace Bulldozer.CSV
         private const int MedicalNote = 28;
         private const int SecurityNote = 29;
         private const int PreviousPersonIds = 30;
+        private const int AlternateEmails = 31;
 
         #endregion Individual Constants
 

--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -625,7 +625,7 @@ namespace Bulldozer.CSV
                     var rowGroupTypeParentId = row[GroupTypeParentId];
                     if ( !string.IsNullOrWhiteSpace( rowGroupTypeParentId ) )
                     {
-                        var parentGroupType = ImportedGroupTypes.FirstOrDefault( t => t.ForeignKey.Equals( rowGroupTypeParentId ) );
+                        var parentGroupType = new GroupTypeService( lookupContext ).Get( ImportedGroupTypes.FirstOrDefault( t => t.ForeignKey.Equals( rowGroupTypeParentId ) ).Guid );
                         var parentGroupTypeList = new List<GroupType>();
                         parentGroupTypeList.Add( parentGroupType );
                         newGroupType.ParentGroupTypes = parentGroupTypeList;

--- a/Bulldozer.CSV/Maps/Individual.cs
+++ b/Bulldozer.CSV/Maps/Individual.cs
@@ -186,7 +186,7 @@ namespace Bulldozer.CSV
                 {
                     foreach ( var key in rowPreviousPersonKeys.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries ) )
                     {
-                        personKeys = GetPersonKeys( key );
+                        personKeys = GetPersonKeys( key.Trim() );
                         if ( personKeys != null )
                         {
                             using ( RockContext context = new RockContext() )

--- a/Bulldozer.CSV/Maps/Individual.cs
+++ b/Bulldozer.CSV/Maps/Individual.cs
@@ -700,7 +700,7 @@ namespace Bulldozer.CSV
                     if ( !string.IsNullOrWhiteSpace( rowAlternateEmails ) )
                     {
                         var emailSearcKeyDVId = DefinedValueCache.Get( new Guid( Rock.SystemGuid.DefinedValue.PERSON_SEARCH_KEYS_EMAIL ) ).Id; 
-                        foreach ( var email in rowAlternateEmails.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries ) )
+                        foreach ( var email in rowAlternateEmails.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries ).Distinct() )
                         {
                             var emailSearchKey = new PersonSearchKey
                             {
@@ -840,10 +840,12 @@ namespace Bulldozer.CSV
         /// <summary>
         /// Saves the individuals.
         /// </summary>
+        /// <param name="mainRockContext">The Rock context.</param>
         /// <param name="newFamilyList">The family list.</param>
         /// <param name="visitorList">The optional visitor list.</param>
         /// <param name="newNoteList">The new note list.</param>
         /// <param name="alternateEmailKeys">The alternate email key list.</param>
+        /// <param name="newFamilyMembers">The new family member list.</param>
         private void SaveIndividuals( RockContext mainRockContext, List<Group> newFamilyList, List<Group> visitorList = null, List<Note> newNoteList = null, List<PersonSearchKey> alternateEmailKeys = null, List<GroupMember> newFamilyMembers = null )
         {
             if ( newFamilyMembers == null )

--- a/Bulldozer.CSV/Maps/Individual.cs
+++ b/Bulldozer.CSV/Maps/Individual.cs
@@ -734,15 +734,15 @@ namespace Bulldozer.CSV
                             currentFamilyGroup = CreateFamilyGroup( row[FamilyName], rowFamilyKey );
                             newFamilyList.Add( currentFamilyGroup );
                             newFamilies++;
+                            currentFamilyGroup.Members.Add( groupMember );
                         }
                         else
                         {
-                            lookupContext.Groups.Attach( currentFamilyGroup );
                             groupMember.GroupId = currentFamilyGroup.Id;
+                            lookupContext.Groups.Attach( currentFamilyGroup );
                             newFamilyMembers.Add( groupMember );
                         }
 
-                        currentFamilyGroup.Members.Add( groupMember );
                     }
                     else
                     {

--- a/Bulldozer.CSV/Maps/Individual.cs
+++ b/Bulldozer.CSV/Maps/Individual.cs
@@ -208,7 +208,7 @@ namespace Bulldozer.CSV
                                 ImportedPeopleKeys.Add( new PersonKeys
                                 {
                                     PersonAliasId = pa.Id,
-                                    GroupForeignId = person.PrimaryFamily.ForeignId,
+                                    GroupForeignId = rowFamilyId,
                                     PersonId = pa.PersonId,
                                     PersonForeignId = pa.ForeignId,
                                     PersonForeignKey = pa.ForeignKey

--- a/Bulldozer.CSV/Maps/Individual.cs
+++ b/Bulldozer.CSV/Maps/Individual.cs
@@ -71,7 +71,7 @@ namespace Bulldozer.CSV
             // Look for custom attributes in the Individual file
             var allFields = csvData.TableNodes.FirstOrDefault().Children.Select( ( node, index ) => new { node = node, index = index } ).ToList();
             var customAttributes = allFields
-                .Where( f => f.index > PreviousPersonIds )
+                .Where( f => f.index > AlternateEmails )
                 .ToDictionary( f => f.index, f => f.node.Name );
 
             var personAttributes = new List<Rock.Model.Attribute>();
@@ -155,8 +155,10 @@ namespace Bulldozer.CSV
 
             var currentFamilyGroup = new Group();
             var newFamilyList = new List<Group>();
+            var newFamilyMembers = new List<GroupMember>();
             var newVisitorList = new List<Group>();
             var newNoteList = new List<Note>();
+            var alternateEmails = new List<PersonSearchKey>();
 
             var completed = 0;
             var newFamilies = 0;
@@ -174,6 +176,7 @@ namespace Bulldozer.CSV
                 var rowFamilyKey = row[FamilyId];
                 var rowPersonKey = row[PersonId];
                 var rowPreviousPersonKeys = row[PreviousPersonIds];
+                var rowAlternateEmails = row[AlternateEmails];
                 var rowFamilyId = rowFamilyKey.AsType<int?>();
                 var rowPersonId = rowPersonKey.AsType<int?>();
 
@@ -693,6 +696,23 @@ namespace Bulldozer.CSV
                         }
                     }
 
+                    // Add any additional emails as search keys
+                    if ( !string.IsNullOrWhiteSpace( rowAlternateEmails ) )
+                    {
+                        var emailSearcKeyDVId = DefinedValueCache.Get( new Guid( Rock.SystemGuid.DefinedValue.PERSON_SEARCH_KEYS_EMAIL ) ).Id; 
+                        foreach ( var email in rowAlternateEmails.Split( new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries ) )
+                        {
+                            var emailSearchKey = new PersonSearchKey
+                            {
+                                SearchTypeValueId = emailSearcKeyDVId,
+                                ForeignKey = rowPersonKey,
+                                ForeignId = rowPersonId,
+                                SearchValue = email.ToLower().Trim()
+                            };
+                            alternateEmails.Add( emailSearchKey );
+                        }
+                    }
+
                     #endregion person create
 
                     var groupMember = new GroupMember
@@ -718,6 +738,8 @@ namespace Bulldozer.CSV
                         else
                         {
                             lookupContext.Groups.Attach( currentFamilyGroup );
+                            groupMember.GroupId = currentFamilyGroup.Id;
+                            newFamilyMembers.Add( groupMember );
                         }
 
                         currentFamilyGroup.Members.Add( groupMember );
@@ -755,15 +777,17 @@ namespace Bulldozer.CSV
 
                     if ( newPeople >= ReportingNumber && rowNextFamilyKey != currentFamilyGroup.ForeignKey )
                     {
-                        SaveIndividuals( newFamilyList, newVisitorList, newNoteList );
+                        SaveIndividuals( lookupContext, newFamilyList, newVisitorList, newNoteList, alternateEmails, newFamilyMembers );
                         lookupContext.SaveChanges();
                         ReportPartialProgress();
 
                         // Clear out variables
                         currentFamilyGroup = new Group();
                         newFamilyList.Clear();
+                        newFamilyMembers.Clear();
                         newVisitorList.Clear();
                         newNoteList.Clear();
+                        alternateEmails.Clear();
                         newPeople = 0;
                     }
                 }
@@ -773,10 +797,10 @@ namespace Bulldozer.CSV
                 }
             }
 
-            // Save any changes to new families
-            if ( newFamilyList.Any() )
+            // Save any changes to new families or new family members
+            if ( newFamilyList.Any() || newFamilyMembers.Any() )
             {
-                SaveIndividuals( newFamilyList, newVisitorList, newNoteList );
+                SaveIndividuals( lookupContext, newFamilyList, newVisitorList, newNoteList, alternateEmails, newFamilyMembers );
             }
 
             // Save any changes to existing families
@@ -819,18 +843,32 @@ namespace Bulldozer.CSV
         /// <param name="newFamilyList">The family list.</param>
         /// <param name="visitorList">The optional visitor list.</param>
         /// <param name="newNoteList">The new note list.</param>
-        private void SaveIndividuals( List<Group> newFamilyList, List<Group> visitorList = null, List<Note> newNoteList = null )
+        /// <param name="alternateEmailKeys">The alternate email key list.</param>
+        private void SaveIndividuals( RockContext mainRockContext, List<Group> newFamilyList, List<Group> visitorList = null, List<Note> newNoteList = null, List<PersonSearchKey> alternateEmailKeys = null, List<GroupMember> newFamilyMembers = null )
         {
-            if ( newFamilyList.Any() )
+            if ( newFamilyMembers == null )
+            {
+                newFamilyMembers = new List<GroupMember>();
+            }
+            if ( newFamilyList.Any() || newFamilyMembers.Any() )
             {
                 var rockContext = new RockContext();
                 rockContext.WrapTransaction( () =>
                 {
-                    rockContext.Groups.AddRange( newFamilyList );
+                    if ( newFamilyList.Any() )
+                    {
+                        rockContext.Groups.AddRange( newFamilyList );
+                    }
+                    if ( newFamilyMembers.Any() )
+                    {
+                        rockContext.GroupMembers.AddRange( newFamilyMembers );
+                    }
                     rockContext.SaveChanges( DisableAuditing );
 
                     // #TODO find out how to track family groups without context locks
                     ImportedFamilies.AddRange( newFamilyList );
+
+                    var newPersonForeignIds = new List<int>();
 
                     foreach ( var familyGroups in newFamilyList.GroupBy( g => g.ForeignKey ) )
                     {
@@ -839,39 +877,8 @@ namespace Bulldozer.CSV
                         {
                             foreach ( var person in newFamilyGroup.Members.Select( m => m.Person ) )
                             {
-                                // Set notes on this person
-                                var personNotes = newNoteList.Where( n => n.ForeignKey == person.ForeignKey ).ToList();
-                                if ( personNotes.Any() )
-                                {
-                                    personNotes.ForEach( n => n.EntityId = person.Id );
-                                }
-
-                                // Set attributes on this person
-                                var personAttributeValues = person.Attributes.Select( a => a.Value )
-                                .Select( a => new AttributeValue
-                                {
-                                    AttributeId = a.Id,
-                                    EntityId = person.Id,
-                                    Value = person.AttributeValues[a.Key].Value
-                                } ).ToList();
-
-                                rockContext.AttributeValues.AddRange( personAttributeValues );
-
-                                // Set aliases on this person
-                                if ( !person.Aliases.Any( a => a.PersonId == person.Id ) )
-                                {
-                                    person.Aliases.Add( new PersonAlias
-                                    {
-                                        AliasPersonId = person.Id,
-                                        AliasPersonGuid = person.Guid,
-                                        ForeignKey = person.ForeignKey,
-                                        ForeignId = person.ForeignId,
-                                        PersonId = person.Id
-                                    } );
-                                }
-
-                                person.GivingGroupId = newFamilyGroup.Id;
-
+                                BuildNewPerson( newNoteList, alternateEmailKeys, rockContext, newFamilyGroup.Id, person );
+                                newPersonForeignIds.Add( person.ForeignId.Value );
                                 if ( visitorsExist )
                                 {
                                     // Retrieve or create the group this person is an owner of
@@ -956,9 +963,46 @@ namespace Bulldozer.CSV
                         }
                     }
 
+                    foreach ( GroupMember famMember in newFamilyMembers )
+                    {
+                        BuildNewPerson( newNoteList, alternateEmailKeys, rockContext, famMember.GroupId, famMember.Person );
+                        newPersonForeignIds.Add( famMember.Person.ForeignId.Value );
+                    }
+
                     // Save notes and all changes
                     rockContext.Notes.AddRange( newNoteList );
                     rockContext.SaveChanges( DisableAuditing );
+
+                    // Set email person search keys
+                    if ( alternateEmailKeys.Count > 0 )
+                    {
+                        foreach ( var foreignId in newPersonForeignIds )
+                        {
+                            Person importedPerson = null;
+                            if ( newFamilyList.Any() )
+                            {
+                                importedPerson = new PersonService( rockContext ).Get( newFamilyList
+                                                    .SelectMany( m => m.Members )
+                                                    .Select( m => m.Person )
+                                                    .FirstOrDefault( p => p.ForeignId == foreignId ).Guid );
+                            }
+                            if ( importedPerson == null && newFamilyMembers.Any() )
+                            {
+                                importedPerson = new PersonService( rockContext ).Get( newFamilyMembers
+                                                    .Select( m => m.Person )
+                                                    .FirstOrDefault( p => p.ForeignId == foreignId ).Guid );
+                            }
+                            if ( importedPerson != null )
+                            {
+                                var emailPersonSearchKeys = alternateEmailKeys.Where( e => e.ForeignId == importedPerson.ForeignId ).ToList();
+                                if ( emailPersonSearchKeys.Any() )
+                                {
+                                    emailPersonSearchKeys.ForEach( k => k.PersonAliasId = importedPerson.PrimaryAliasId );
+                                }
+                            }
+                        }
+                        mainRockContext.PersonSearchKeys.AddRange( alternateEmailKeys );
+                    }
 
                     if ( refreshIndividualListEachCycle )
                     {
@@ -975,10 +1019,57 @@ namespace Bulldozer.CSV
                                 PersonForeignKey = p.Person.ForeignKey
                             } )
                         );
+                        ImportedPeopleKeys.AddRange(
+                            newFamilyMembers.Where( m => m.ForeignKey != null )
+                            .Select( p => new PersonKeys
+                            {
+                                PersonAliasId = ( int ) p.Person.PrimaryAliasId,
+                                GroupForeignId = p.Group.ForeignId,
+                                PersonId = p.Person.Id,
+                                PersonForeignId = p.Person.ForeignId,
+                                PersonForeignKey = p.Person.ForeignKey
+                            } )
+                        );
                         ImportedPeopleKeys = ImportedPeopleKeys.OrderBy( k => k.PersonForeignId ).ThenBy( k => k.PersonForeignKey ).ToList();
                     }
                 } );
             }
+        }
+
+        private static void BuildNewPerson( List<Note> newNoteList, List<PersonSearchKey> alternateEmails, RockContext rockContext, int familyGroupId, Person newPerson )
+        {
+            // Set notes on this person
+            var personNotes = newNoteList.Where( n => n.ForeignKey == newPerson.ForeignKey ).ToList();
+            if ( personNotes.Any() )
+            {
+                personNotes.ForEach( n => n.EntityId = newPerson.Id );
+            }
+
+            // Set attributes on this person
+            var personAttributeValues = newPerson.Attributes.Select( a => a.Value )
+            .Select( a => new AttributeValue
+            {
+                AttributeId = a.Id,
+                EntityId = newPerson.Id,
+                Value = newPerson.AttributeValues[a.Key].Value
+            } ).ToList();
+
+            rockContext.AttributeValues.AddRange( personAttributeValues );
+
+            // Set aliases on this person
+            if ( !newPerson.Aliases.Any( a => a.PersonId == newPerson.Id ) )
+            {
+                newPerson.Aliases.Add( new PersonAlias
+                {
+                    AliasPersonId = newPerson.Id,
+                    AliasPersonGuid = newPerson.Guid,
+                    ForeignKey = newPerson.ForeignKey,
+                    ForeignId = newPerson.ForeignId,
+                    PersonId = newPerson.Id
+                } );
+            }
+
+            newPerson.GivingGroupId = familyGroupId;
         }
 
         #endregion Main Methods

--- a/Bulldozer.CSV/SampleCSVs/01 - Individual.csv
+++ b/Bulldozer.CSV/SampleCSVs/01 - Individual.csv
@@ -1,8 +1,8 @@
-FamilyId,FamilyName,CreatedDate,PersonId,Prefix,FirstName,NickName,MiddleName,LastName,Suffix,FamilyRole,MaritalStatus,ConnectionStatus,RecordStatus,IsDeceased,HomePhone,MobilePhone,WorkPhone,Allow SMS?,Email,Is Email Active?,Allow Bulk Email?,Gender,DateOfBirth,School,GraduationDate,Anniversary,General Note,MedicalNote,Security Note,^New Category Test^New Date Attribute Test^D,^New Category Test^New Text Attribute,^New Category Test 2^Another New Attribute,Simple New Attribute
-96811879691115097A,Smith Family,10/29/04,25570361,Mr,John,Jay,Adam,Smith,,Adult,Married,Member,Active,,,+44 0827-345-1163,+1 (804) 237-9876,Yes,jsmitha@windowslive.com,Yes,Yes,Male,,Belvedere Community,06/01/08,,general note 1^[ALERT]general note 2^general note 3,medical,security,10/11/2008,blah1,blah2,blah3
-96811879691115097A,Smith Family,,140,,Barbara,,,Smith,,Adult,,,,,,,,,,,,Female,,,,,general note,,,10/11/2008,blah1,blah2,blah3
-96811879691115097A,Smith Family,,142,,Caleb,,,Smith,,Child,,,,,,,,,,,,Male,04/01/12,,,,,medical note,,10/11/2008,blah1,blah2,blah3
-968111412207101120A,Meese Family,,145,Mr,Allen,,,Meese,,Adult,Married,Attendee,Active,,,8645719853,,Yes,,,,Male,01/05/83,,,,,,security,10/11/2008,blah1,blah2,blah3
-968111412207101120A,Meese Family,,146,Mrs,Sara,,,Meese,,Adult,Married,Attendee,Active,,,864-938-1593,,No,smeese@gmail.com,Yes,,Female,06/09/85,,,,,,,10/11/2008,blah1,blah2,blah3
-968111412207101120A,Meese Family,,147,,Oliver,,,Meese,,Child,,,,,,,,,,,,Male,05/01/11,,,,,,,,,,
-968111412207101120A,Meese Family,,148,,Debra,,,Meese,,Child,,,,,,,,,,,,Female,01/01/09,,,,,,,,,,
+FamilyId,FamilyName,CreatedDate,PersonId,Prefix,FirstName,NickName,MiddleName,LastName,Suffix,FamilyRole,MaritalStatus,ConnectionStatus,RecordStatus,IsDeceased,HomePhone,MobilePhone,WorkPhone,Allow SMS?,Email,Is Email Active?,Allow Bulk Email?,Gender,DateOfBirth,School,GraduationDate,Anniversary,General Note,MedicalNote,Security Note,PreviousPersonIds,^New Category Test^New Date Attribute Test^D,^New Category Test^New Text Attribute,^New Category Test 2^Another New Attribute,Simple New Attribute
+96811879691115097A,Smith Family,10/29/2004,25570361,Mr,John,Jay,Adam,Smith,,Adult,Married,Member,Active,,,+44 0827-345-1163,+1 (804) 237-9876,Yes,jsmitha@windowslive.com,Yes,Yes,Male,,Belvedere Community,6/1/2008,,general note 1^[ALERT]general note 2^general note 3,medical,security,"201,531,814,498",10/11/2008,blah1,blah2,blah3
+96811879691115097A,Smith Family,,140,,Barbara,,,Smith,,Adult,,,,,,,,,,,,Female,,,,,general note,,,,10/11/2008,blah1,blah2,blah3
+96811879691115097A,Smith Family,,142,,Caleb,,,Smith,,Child,,,,,,,,,,,,Male,4/1/2012,,,,,medical note,,1163,10/11/2008,blah1,blah2,blah3
+968111412207101120A,Meese Family,,145,Mr,Allen,,,Meese,,Adult,Married,Attendee,Active,,,8645719853,,Yes,,,,Male,1/5/1983,,,,,,security,,10/11/2008,blah1,blah2,blah3
+968111412207101120A,Meese Family,,146,Mrs,Sara,,,Meese,,Adult,Married,Attendee,Active,,,864-938-1593,,No,smeese@gmail.com,Yes,,Female,6/9/1985,,,,,,,,10/11/2008,blah1,blah2,blah3
+968111412207101120A,Meese Family,,147,,Oliver,,,Meese,,Child,,,,,,,,,,,,Male,5/1/2011,,,,,,,"5,981,853",,,,
+968111412207101120A,Meese Family,,148,,Debra,,,Meese,,Child,,,,,,,,,,,,Female,1/1/2009,,,,,,,,,,,

--- a/Bulldozer.CSV/SampleCSVs/01 - Individual.csv
+++ b/Bulldozer.CSV/SampleCSVs/01 - Individual.csv
@@ -1,8 +1,8 @@
-FamilyId,FamilyName,CreatedDate,PersonId,Prefix,FirstName,NickName,MiddleName,LastName,Suffix,FamilyRole,MaritalStatus,ConnectionStatus,RecordStatus,IsDeceased,HomePhone,MobilePhone,WorkPhone,Allow SMS?,Email,Is Email Active?,Allow Bulk Email?,Gender,DateOfBirth,School,GraduationDate,Anniversary,General Note,MedicalNote,Security Note,PreviousPersonIds,^New Category Test^New Date Attribute Test^D,^New Category Test^New Text Attribute,^New Category Test 2^Another New Attribute,Simple New Attribute
-96811879691115097A,Smith Family,10/29/2004,25570361,Mr,John,Jay,Adam,Smith,,Adult,Married,Member,Active,,,+44 0827-345-1163,+1 (804) 237-9876,Yes,jsmitha@windowslive.com,Yes,Yes,Male,,Belvedere Community,6/1/2008,,general note 1^[ALERT]general note 2^general note 3,medical,security,"201,531,814,498",10/11/2008,blah1,blah2,blah3
-96811879691115097A,Smith Family,,140,,Barbara,,,Smith,,Adult,,,,,,,,,,,,Female,,,,,general note,,,,10/11/2008,blah1,blah2,blah3
-96811879691115097A,Smith Family,,142,,Caleb,,,Smith,,Child,,,,,,,,,,,,Male,4/1/2012,,,,,medical note,,1163,10/11/2008,blah1,blah2,blah3
-968111412207101120A,Meese Family,,145,Mr,Allen,,,Meese,,Adult,Married,Attendee,Active,,,8645719853,,Yes,,,,Male,1/5/1983,,,,,,security,,10/11/2008,blah1,blah2,blah3
-968111412207101120A,Meese Family,,146,Mrs,Sara,,,Meese,,Adult,Married,Attendee,Active,,,864-938-1593,,No,smeese@gmail.com,Yes,,Female,6/9/1985,,,,,,,,10/11/2008,blah1,blah2,blah3
-968111412207101120A,Meese Family,,147,,Oliver,,,Meese,,Child,,,,,,,,,,,,Male,5/1/2011,,,,,,,"5,981,853",,,,
-968111412207101120A,Meese Family,,148,,Debra,,,Meese,,Child,,,,,,,,,,,,Female,1/1/2009,,,,,,,,,,,
+FamilyId,FamilyName,CreatedDate,PersonId,Prefix,FirstName,NickName,MiddleName,LastName,Suffix,FamilyRole,MaritalStatus,ConnectionStatus,RecordStatus,IsDeceased,HomePhone,MobilePhone,WorkPhone,Allow SMS?,Email,Is Email Active?,Allow Bulk Email?,Gender,DateOfBirth,School,GraduationDate,Anniversary,General Note,MedicalNote,Security Note,PreviousPersonIds,AlternateEmails,^New Category Test^New Date Attribute Test^D,^New Category Test^New Text Attribute,^New Category Test 2^Another New Attribute,Simple New Attribute
+96811879691115097A,Smith Family,10/29/2004,25570361,Mr,John,Jay,Adam,Smith,,Adult,Married,Member,Active,,,+44 0827-345-1163,+1 (804) 237-9876,Yes,jsmitha@windowslive.com,Yes,Yes,Male,,Belvedere Community,6/1/2008,,general note 1^[ALERT]general note 2^general note 3,medical,security,"201,531,814,498",johnJay@gmail.com,10/11/2008,blah1,blah2,blah3
+96811879691115097A,Smith Family,,140,,Barbara,,,Smith,,Adult,,,,,,,,,,,,Female,,,,,general note,,,,,10/11/2008,blah1,blah2,blah3
+96811879691115097A,Smith Family,,142,,Caleb,,,Smith,,Child,,,,,,,,,,,,Male,4/1/2012,,,,,medical note,,1163,,10/11/2008,blah1,blah2,blah3
+968111412207101120A,Meese Family,,145,Mr,Allen,,,Meese,,Adult,Married,Attendee,Active,,,8645719853,,Yes,,,,Male,1/5/1983,,,,,,security,,,10/11/2008,blah1,blah2,blah3
+968111412207101120A,Meese Family,,146,Mrs,Sara,,,Meese,,Adult,Married,Attendee,Active,,,864-938-1593,,No,smeese@gmail.com,Yes,,Female,6/9/1985,,,,,,,,"workingmom@gmail.com,smeese@fbc.org",10/11/2008,blah1,blah2,blah3
+968111412207101120A,Meese Family,,147,,Oliver,,,Meese,,Child,,,,,,,,,,,,Male,5/1/2011,,,,,,,"5,981,853",,,,,
+968111412207101120A,Meese Family,,148,,Debra,,,Meese,,Child,,,,,,,,,,,,Female,1/1/2009,,,,,,,,,,,,


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added support to pass comma separated list of previous person ids in a column named PreviousPersonIds. If a value is provided in this column, the Individual import portion of the CSV component will include those ids as it searches for previously imported records. If it locates a match based on one of the previous ids and not the primary PersonId field, it will add a PersonAlias entry to the Rock record with a foreign key of the primary PersonId provided.
Added support for importing alternate email addresses as PersonSearchKeys by providing a comma separated list of emails in a column named AlternateEmails.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?
##### CSV Importing  

* Added support to pass comma separated list of previous person ids in a column named PreviousPersonIds.  
* Added support to pass comma separated list of alternate emails in a column named AlternateEmails.  
* Fixed undocumented bug causing person records imported into families that already exist in the database to not be fully and properly built.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Grace Family of Churches

---------

### Screenshots

##### Does this update or add options to the block UI?

none

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/CSVComponent.cs
* Bulldozer.CSV/Maps/Individual.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

Requires an additional column titled "PreviousPersonIds" be added to Individual csv file for individual import to work moving forward.
