### PR TITLE
Binary attribute import fixes

### DIFF
--- a/Bulldozer.BinaryFile/BinaryFileComponent.cs
+++ b/Bulldozer.BinaryFile/BinaryFileComponent.cs
@@ -239,6 +239,7 @@ namespace Bulldozer.BinaryFile
                     newFileType.Name = typeKey;
                     newFileType.Description = typeKey;
                     newFileType.CacheToServerFileSystem = true;
+                    newFileType.CacheControlHeaderSettings = "{\"RockCacheablityType\":3,\"MaxAge\":null,\"MaxSharedAge\":null}";
 
                     var typeValue = binaryTypeSettings[typeKey];
                     if ( typeValue != null )

--- a/Bulldozer.BinaryFile/Maps/MinistryDocument.cs
+++ b/Bulldozer.BinaryFile/Maps/MinistryDocument.cs
@@ -157,7 +157,7 @@ namespace Bulldozer.BinaryFile
                             IsRequired = false,
                             AllowSearch = false,
                             IsSystem = false,
-                            Order = 0,
+                            Order = 0
                         };
 
                         fileAttribute.AttributeQualifiers.Add( new AttributeQualifier()
@@ -166,8 +166,8 @@ namespace Bulldozer.BinaryFile
                             Value = ministryFileType.Guid.ToString()
                         } );
 
-                        lookupContext.Attributes.Add( fileAttribute );
                         fileAttribute.Categories.Add( fileAttributeCategory );
+                        lookupContext.Attributes.Add( fileAttribute );
                         lookupContext.SaveChanges();
 
                         existingAttributes.Add( fileAttribute.Key, fileAttribute );


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

* Add Attribute category for imported ministry documents.  
* Fixed bug #59 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Add Attribute category for imported ministry documents.  
* Fixed a bug causing imported Group image attributes to not display properly

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

none  

---------

### Change Log

##### What files does it affect?

* Bulldozer.BinaryFile/BinaryFileComponent.csc  
* Bulldozer.BinaryFile/Maps/MinistryDocument.cs  
  
---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
