### PR TITLE
Minor Bug Fixes

### DIFF
--- a/Bulldozer.BinaryFile/Maps/MinistryDocument.cs
+++ b/Bulldozer.BinaryFile/Maps/MinistryDocument.cs
@@ -90,6 +90,7 @@ namespace Bulldozer.BinaryFile
                 lookupContext.Categories.Add( fileAttributeCategory );
                 lookupContext.SaveChanges();
             }
+            fileAttributeCategory = new CategoryService( lookupContext ).Get( fileAttributeCategory.Guid );
 
             foreach ( var file in folder.Entries.OrderBy( f => f.Name ) )
             {
@@ -165,7 +166,6 @@ namespace Bulldozer.BinaryFile
                             Key = "binaryFileType",
                             Value = ministryFileType.Guid.ToString()
                         } );
-
                         fileAttribute.Categories.Add( fileAttributeCategory );
                         lookupContext.Attributes.Add( fileAttribute );
                         lookupContext.SaveChanges();

--- a/Bulldozer.CSV/Maps/Financial.cs
+++ b/Bulldozer.CSV/Maps/Financial.cs
@@ -1448,13 +1448,10 @@ namespace Bulldozer.CSV
                     }
                     else
                     {
-                        throw new ArgumentOutOfRangeException( $"Cannot find person alias with person key '{rowPersonKey}' for scheduled transaction key {rowTransactionKey}" );
+                        LogException( "InvalidPersonAlias", string.Format( "Cannot find person alias with person key '{0}' for scheduled transaction key {1}", rowPersonKey, rowTransactionKey ) );
+                        currentTransaction = new FinancialScheduledTransaction();
+                        continue;
                     }
-
-                    currentTransaction.CreatedDateTime = ParseDateOrDefault( row[ScheduledTransactionCreatedDate], ImportDateTime );
-                    currentTransaction.ModifiedDateTime = ImportDateTime;
-                    currentTransaction.CreatedByPersonAliasId = personKeys.PersonAliasId;
-                    currentTransaction.ModifiedByPersonAliasId = personKeys.PersonAliasId;
 
                     var startDate = ParseDateOrDefault( row[ScheduledTransactionStartDate], null );
                     if ( startDate == null )

--- a/Bulldozer.CSV/Maps/GroupMember.cs
+++ b/Bulldozer.CSV/Maps/GroupMember.cs
@@ -44,7 +44,7 @@ namespace Bulldozer.CSV
             var groupMemberService = new GroupMemberService( lookupContext );
 
             Dictionary<string, int> importedMembers = groupMemberService.Queryable( true ).AsNoTracking()
-                .Where( m => m.ForeignKey != null )
+                .Where( m => m.ForeignKey != null && m.Group.GroupTypeId != CachedTypes.KnownRelationshipGroupType.Id )
                 .ToDictionary( m => m.ForeignKey, m => m.Id );
 
             var groupTypeRoles = new Dictionary<int?, Dictionary<string, int>>();

--- a/Bulldozer.CSV/Maps/Individual.cs
+++ b/Bulldozer.CSV/Maps/Individual.cs
@@ -983,10 +983,14 @@ namespace Bulldozer.CSV
                             Person importedPerson = null;
                             if ( newFamilyList.Any() )
                             {
-                                importedPerson = new PersonService( rockContext ).Get( newFamilyList
+                                var importedPersonObj = newFamilyList
                                                     .SelectMany( m => m.Members )
                                                     .Select( m => m.Person )
-                                                    .FirstOrDefault( p => p.ForeignId == foreignId ).Guid );
+                                                    .FirstOrDefault( p => p.ForeignId == foreignId );
+                                if ( importedPersonObj != null )
+                                {
+                                    importedPerson = new PersonService( rockContext ).Get( importedPersonObj.Guid );
+                                }
                             }
                             if ( importedPerson == null && newFamilyMembers.Any() )
                             {


### PR DESCRIPTION
### Description 
  
Fixed a couple minor bugs discovered during a migration.  
   
##### What does the change add or fix?

* Added null check logic to fix null ref exception during certain scenarios of person importing.  
* Fixed bug causing Bulldozer to throw duplicate key exception in some cases during GroupMember import.  
* Update logic to record exception and continue rather than throw exception when trying to import a ScheduledTransaction with a ScheduledTransactionPersonId that does not exist.  
* Fixed a bug with Category creation logic for Ministry Documents introduced in last update.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Added null check logic to fix null ref exception during certain scenarios of person importing.  
* Fixed bug causing Bulldozer to throw duplicate key exception in some cases during GroupMember import.  
* Update logic to record exception and continue rather than throw exception when trying to import a ScheduledTransaction with a ScheduledTransactionPersonId that does not exist.  
* Fixed a bug with Category creation logic for Ministry Documents introduced in last update.


---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

none

---------

### Change Log

##### What files does it affect?

* Bulldozer.BinaryFile/Maps/MinistryDocument.cs  
* Bulldozer.CSV/Maps/Financial.cs  
* Bulldozer.CSV/Maps/GroupMember.cs  
* Bulldozer.CSV/Maps/Individual.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
