### PR TITLE
Fixed Date attribute qualifier key casing

### DIFF
--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -963,7 +963,7 @@ namespace Bulldozer.Utility
 
                     attributeQualifier = new AttributeQualifier
                     {
-                        Key = "displaydiff",
+                        Key = "displayDiff",
                         Value = "false",
                         IsSystem = false
                     };
@@ -972,7 +972,7 @@ namespace Bulldozer.Utility
 
                     attributeQualifier = new AttributeQualifier
                     {
-                        Key = "displaycurrentoption",
+                        Key = "displayCurrentOption",
                         Value = "false",
                         IsSystem = false
                     };


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Somewhere along the line in Rock versions, the reading of the "displayDiff" and "displayCurrentOption" attribute qualifiers from the db became case sensitive. Bulldozer historically imported these qualifiers with all lower case letters for the key names. This now causes any edit attempts on imported Date attributes to result in an exception. This update causes the qualifier keys to match casing of Rock system code, thus fixing the ability to edit Date attributes. 

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* fixed bug causing imported Date attributes to throw exceptions when edited.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

Exception that was being thrown before fix:  
![image](https://user-images.githubusercontent.com/7374281/181346833-2cb25ff4-e365-44a7-b571-6e5867f5788f.png)

---------

### Change Log

##### What files does it affect?

* Bulldozer/Utility/AddMethods.cs  

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

none
