### PR TITLE
More Phone country codes and NonCashType for contributions

### DIFF
--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -808,6 +808,7 @@ namespace Bulldozer.CSV
         private const int ScheduledTransactionForeignKey = 18;
         private const int FundId = 19;
         private const int SourceType = 20;
+        private const int NonCashTypeType = 21;
 
         #endregion Contribution Constants
 

--- a/Bulldozer.CSV/CSVPhoneCountryCode.cs
+++ b/Bulldozer.CSV/CSVPhoneCountryCode.cs
@@ -58,6 +58,24 @@ namespace Bulldozer.CSV
         };
 
         public static CountryCodeData GermanLandLineOr3DigitPrefixMobile = new CountryCodeData
+        public static CountryCodeData UkraineMobile = new CountryCodeData
+        {
+            CountryCode = 380,
+            Description = "Ukrainian Mobile Phone Number",
+            MatchExpression = @"^(39|50|63|66|67|68|91|92|93|94|95|96|97|98|99)(\d{3})(\d{4})$",
+            FormatExpression = @"$1 $2 $3",
+            Order = 0
+        };
+
+        public static CountryCodeData UkraineMobileWithCountry = new CountryCodeData
+        {
+            CountryCode = 380,
+            Description = "Ukrainian Mobile Phone Number with Country Code",
+            MatchExpression = @"^380(39|50|63|66|67|68|91|92|93|94|95|96|97|98|99)(\d{3})(\d{4})$",
+            FormatExpression = @"$1 $2 $3",
+            Order = 1
+        };
+
         {
             CountryCode = 49,
             Description = "German Land Line or 3 Digit Prefix Mobile Phone Number",
@@ -103,6 +121,22 @@ namespace Bulldozer.CSV
             Description = "Ghanaian Phone Number with Country Code",
             MatchExpression = @"^233(\d{2})(\d{3})(\d{4})$",
             FormatExpression = @"$1 $2 $3"
+        };
+
+        public static CountryCodeData India = new CountryCodeData
+        {
+            CountryCode = 91,
+            Description = "Indian Phone Number",
+            MatchExpression = @"^(\d{5})(\d{5})$",
+            FormatExpression = @"$1 $2"
+        };
+
+        public static CountryCodeData IndiaWithCountry = new CountryCodeData
+        {
+            CountryCode = 91,
+            Description = "Indian Phone Number with Country Code",
+            MatchExpression = @"^91(\d{5})(\d{5})$",
+            FormatExpression = @"$1 $2"
         };
 
         public static CountryCodeData JapanNineDigit = new CountryCodeData
@@ -249,6 +283,42 @@ namespace Bulldozer.CSV
             FormatExpression = @"$1-$2-$3"
         };
 
+        public static CountryCodeData PolandMobile = new CountryCodeData
+        {
+            CountryCode = 48,
+            Description = "Polish Mobile Phone Number",
+            MatchExpression = @"^(45|50|51|53|57|60|66|69|72|73|78|79|88)(\d{1})(\d{3})(\d{3})$",
+            FormatExpression = @"$1$2 $3 $4",
+            Order = 0
+        };
+
+        public static CountryCodeData PolandMobileWithCountry = new CountryCodeData
+        {
+            CountryCode = 48,
+            Description = "Polish Mobile Phone Number with Country Code",
+            MatchExpression = @"^48(45|50|51|53|57|60|66|69|72|73|78|79|88)(\d{1})(\d{3})(\d{3})$",
+            FormatExpression = @"$1$2 $3 $4",
+            Order = 1
+        };
+
+        public static CountryCodeData Poland = new CountryCodeData
+        {
+            CountryCode = 48,
+            Description = "Polish Phone Number",
+            MatchExpression = @"^(\d{2})(\d{3})(\d{2})(\d{2})$",
+            FormatExpression = @"$1 $2 $3 $4",
+            Order = 2
+        };
+
+        public static CountryCodeData PolandWithCountry = new CountryCodeData
+        {
+            CountryCode = 48,
+            Description = "Polish Phone Number with Country Code",
+            MatchExpression = @"^48(\d{2})(\d{3})(\d{2})(\d{2})$",
+            FormatExpression = @"$1 $2 $3 $4",
+            Order = 3
+        };
+
         public static CountryCodeData Romania = new CountryCodeData
         {
             CountryCode = 40,
@@ -295,6 +365,42 @@ namespace Bulldozer.CSV
             Description = "Spanish Phone Number with Country Code",
             MatchExpression = @"^34(\d{2})(\d{4})(\d{3})$",
             FormatExpression = @"$1 $2-$3"
+        };
+
+        public static CountryCodeData UkraineMobile = new CountryCodeData
+        {
+            CountryCode = 380,
+            Description = "Ukrainian Mobile Phone Number",
+            MatchExpression = @"^(39|50|63|66|67|68|91|92|93|94|95|96|97|98|99)(\d{3})(\d{4})$",
+            FormatExpression = @"$1 $2 $3",
+            Order = 0
+        };
+
+        public static CountryCodeData UkraineMobileWithCountry = new CountryCodeData
+        {
+            CountryCode = 380,
+            Description = "Ukrainian Mobile Phone Number with Country Code",
+            MatchExpression = @"^380(39|50|63|66|67|68|91|92|93|94|95|96|97|98|99)(\d{3})(\d{4})$",
+            FormatExpression = @"$1 $2 $3",
+            Order = 1
+        };
+
+        public static CountryCodeData Ukraine = new CountryCodeData
+        {
+            CountryCode = 380,
+            Description = "Ukrainian Phone Number",
+            MatchExpression = @"^(\d{3})(\d{3})(\d{3})$",
+            FormatExpression = @"$1 $2 $3",
+            Order = 2
+        };
+
+        public static CountryCodeData UkraineWithCountry = new CountryCodeData
+        {
+            CountryCode = 380,
+            Description = "Ukrainian Phone Number with Country Code",
+            MatchExpression = @"^380(\d{3})(\d{3})(\d{3})$",
+            FormatExpression = @"$1 $2 $3",
+            Order = 3
         };
 
         public static CountryCodeData UnitedArabEmirates = new CountryCodeData

--- a/Bulldozer.CSV/CSVPhoneCountryCode.cs
+++ b/Bulldozer.CSV/CSVPhoneCountryCode.cs
@@ -57,7 +57,6 @@ namespace Bulldozer.CSV
             FormatExpression = @"$1 $2 $3"
         };
 
-        public static CountryCodeData GermanLandLineOr3DigitPrefixMobile = new CountryCodeData
         public static CountryCodeData UkraineMobile = new CountryCodeData
         {
             CountryCode = 380,
@@ -76,35 +75,58 @@ namespace Bulldozer.CSV
             Order = 1
         };
 
+        public static CountryCodeData Germany3DigitPrefixMobile = new CountryCodeData
         {
             CountryCode = 49,
-            Description = "German Land Line or 3 Digit Prefix Mobile Phone Number",
-            MatchExpression = @"^(\d{3})(\d{7})$",
-            FormatExpression = @"$1 $2"
+            Description = "German 3 Digit Prefix Mobile Phone Number",
+            MatchExpression = @"^(16|17)(\d{1})(\d{7})$",
+            FormatExpression = @"$1$2 $3",
+            Order = 0
         };
 
-        public static CountryCodeData GermanLandLineOr3DigitPrefixMobileWithCountry = new CountryCodeData
+        public static CountryCodeData Germany3DigitPrefixMobileWithCountry = new CountryCodeData
         {
             CountryCode = 49,
-            Description = "German Land Line or 3 Digit Prefix Mobile Phone Number with Country Code",
-            MatchExpression = @"^49(\d{3})(\d{7})$",
-            FormatExpression = @"$1 $2"
+            Description = "German 3 Digit Prefix Mobile Phone Number with Country Code",
+            MatchExpression = @"^49(16|17)(\d{1})(\d{7})$",
+            FormatExpression = @"$1$2 $3",
+            Order = 1
         };
 
-        public static CountryCodeData German4DigitPrefixMobile = new CountryCodeData
+        public static CountryCodeData Germany4DigitPrefixMobile = new CountryCodeData
         {
             CountryCode = 49,
-            Description = "German Mobile Phone Number with 4 Digit Prefix",
-            MatchExpression = @"^(\d{4})(\d{7})$",
-            FormatExpression = @"$1 $2"
+            Description = "German 4 Digit Prefix Mobile Phone Number",
+            MatchExpression = @"^(15)(\d{2})(\d{7})$",
+            FormatExpression = @"$1$2 $3",
+            Order = 2
         };
 
-        public static CountryCodeData German4DigitPrefixMobileWithCountry = new CountryCodeData
+        public static CountryCodeData Germany4DigitPrefixMobileWithCountry = new CountryCodeData
         {
             CountryCode = 49,
             Description = "German 4 digit prefix Mobile Phone Number with Country Code",
-            MatchExpression = @"^49(\d{4})(\d{7})$",
-            FormatExpression = @"$1 $2"
+            MatchExpression = @"^49(15)(\d{2})(\d{7})$",
+            FormatExpression = @"$1$2 $3",
+            Order = 3
+        };
+
+        public static CountryCodeData Germany = new CountryCodeData
+        {
+            CountryCode = 49,
+            Description = "German Phone Number",
+            MatchExpression = @"^(\d{3})(\d{7})$",
+            FormatExpression = @"$1 $2",
+            Order = 4
+        };
+
+        public static CountryCodeData GermanyWithCountry = new CountryCodeData
+        {
+            CountryCode = 49,
+            Description = "German Phone Number with Country Code",
+            MatchExpression = @"^49(\d{3})(\d{7})$",
+            FormatExpression = @"$1 $2",
+            Order = 5
         };
 
         public static CountryCodeData Ghana = new CountryCodeData

--- a/Bulldozer.CSV/CSVPhoneCountryCode.cs
+++ b/Bulldozer.CSV/CSVPhoneCountryCode.cs
@@ -355,5 +355,7 @@ namespace Bulldozer.CSV
         public string MatchExpression { get; set; }
 
         public string FormatExpression { get; set; }
+
+        public int? Order { get; set; }
     }
 }

--- a/Bulldozer.CSV/Maps/Financial.cs
+++ b/Bulldozer.CSV/Maps/Financial.cs
@@ -873,6 +873,17 @@ namespace Bulldozer.CSV
                     else if ( contributionType.Equals( "non-cash", StringComparison.OrdinalIgnoreCase ) || contributionType.Equals( "noncash", StringComparison.OrdinalIgnoreCase ) )
                     {
                         paymentCurrencyTypeId = currencyTypeNonCash;
+                        var noncashTypeName = row[NonCashTypeType];
+                        if ( noncashTypeName.IsNotNullOrWhiteSpace() )
+                        {
+                            var noncashTypeTypeDTGuid = Rock.SystemGuid.DefinedType.FINANCIAL_NONCASH_ASSET_TYPE.AsGuid();
+                            var noncashTypeDV = FindDefinedValueByTypeAndName( lookupContext, noncashTypeTypeDTGuid, noncashTypeName );
+                            if ( noncashTypeDV == null )
+                            {
+                                noncashTypeDV = AddDefinedValue( new RockContext(), noncashTypeTypeDTGuid.ToString(), noncashTypeName );
+                            }
+                            transaction.NonCashAssetTypeValueId = noncashTypeDV.Id;
+                        }
                     }
                     else
                     {

--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -42,7 +42,7 @@ namespace Bulldozer.Utility
         /// <param name="value">The value of the new defined value.</param>
         /// <param name="guid">An optional guid to set for the newly created defined value guid.</param>
         /// <returns></returns>
-        public static DefinedValueCache AddDefinedValue( RockContext rockContext, string typeGuid, string value, string guid = "", string description = "" )
+        public static DefinedValueCache AddDefinedValue( RockContext rockContext, string typeGuid, string value, string guid = "", string description = "", int? order = null )
         {
             DefinedValueCache definedValueCache = null;
             if ( string.IsNullOrWhiteSpace( description ) )
@@ -62,8 +62,15 @@ namespace Bulldozer.Utility
                     Description = description
                 };
 
-                var maxOrder = definedType.DefinedValues.Max( v => ( int? ) v.Order );
-                definedValue.Order = maxOrder + 1 ?? 0;
+                if ( order.HasValue )
+                {
+                    definedValue.Order = order.Value;
+                }
+                else
+                {
+                    var maxOrder = definedType.DefinedValues.Max( v => ( int? ) v.Order );
+                    definedValue.Order = maxOrder + 1 ?? 0;
+                }
 
                 if ( !string.IsNullOrWhiteSpace( guid ) )
                 {

--- a/Bulldozer/Utility/Extensions.cs
+++ b/Bulldozer/Utility/Extensions.cs
@@ -145,9 +145,13 @@ namespace Bulldozer.Utility
         /// </summary>
         /// <param name="email">The string to validate</param>
         /// <returns>true if valid email, false otherwise</returns>
-        public static bool IsEmail( this string email )
+        public static bool IsEmail( this string email, string pattern = null )
         {
-            return Regex.IsMatch( email, @"^(?!((http|https):\/\/|www\.))[\w\.\'_%-]+(\+[\w-]*)?@([\w-]+\.)+[\w-]+$" );
+            if ( string.IsNullOrWhiteSpace( pattern ) )
+            {
+                pattern = @"^(?!((http|https):\/\/|www\.))[\w\.\'_%-]+(\+[\w-]*)?@([\w-]+\.)+[\w-]+$";
+            }
+            return Regex.IsMatch( email, pattern );
         }
 
         /// <summary>


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added a few more supported phone country codes as well as support for NonCashType on imported contributions.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

- Added country code support for Costa Rica, India, Poland, and Ukraine.
- Added support for non-cash type for contributions.
- Updated email validation to use Person.Email RegularExpression custom property pattern.

---------

### Requested By

##### Who reported, requested, or paid for the change?

KFS

---------

### Screenshots

##### Does this update or add options to the block UI?

none

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/CSVComponent.cs
* Bulldozer.CSV/CSVPhoneCountryCode.cs
* Bulldozer.CSV/Maps/Financial.cs
* Bulldozer.CSV/Maps/Individual.cs
* Bulldozer/Utility/AddMethods.cs
* Bulldozer/Utility/Extensions.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
