### PR TITLE
Fix mishap from last MR where duplicate Ukraine entries were copied i…

### DIFF
--- a/Bulldozer.CSV/CSVPhoneCountryCode.cs
+++ b/Bulldozer.CSV/CSVPhoneCountryCode.cs
@@ -55,24 +55,22 @@ namespace Bulldozer.CSV
             Description = "Cambodian Phone Number with Country Code",
             MatchExpression = @"^855(\d{2})(\d{3})(\d{3})$",
             FormatExpression = @"$1 $2 $3"
+        }; 
+        
+        public static CountryCodeData CostaRica = new CountryCodeData
+        {
+            CountryCode = 506,
+            Description = "Costa Rican Phone Number",
+            MatchExpression = @"^(\d{4})(\d{4})$",
+            FormatExpression = @"$1 $2"
         };
 
-        public static CountryCodeData UkraineMobile = new CountryCodeData
+        public static CountryCodeData CostaRicaWithCountry = new CountryCodeData
         {
-            CountryCode = 380,
-            Description = "Ukrainian Mobile Phone Number",
-            MatchExpression = @"^(39|50|63|66|67|68|91|92|93|94|95|96|97|98|99)(\d{3})(\d{4})$",
-            FormatExpression = @"$1 $2 $3",
-            Order = 0
-        };
-
-        public static CountryCodeData UkraineMobileWithCountry = new CountryCodeData
-        {
-            CountryCode = 380,
-            Description = "Ukrainian Mobile Phone Number with Country Code",
-            MatchExpression = @"^380(39|50|63|66|67|68|91|92|93|94|95|96|97|98|99)(\d{3})(\d{4})$",
-            FormatExpression = @"$1 $2 $3",
-            Order = 1
+            CountryCode = 506,
+            Description = "Costa Rican Phone Number with Country Code",
+            MatchExpression = @"^506(\d{4})(\d{4})$",
+            FormatExpression = @"$1 $2"
         };
 
         public static CountryCodeData Germany3DigitPrefixMobile = new CountryCodeData


### PR DESCRIPTION
…nstead of Costa Rica numbers

**Thank you for your code contribution, we will take your code suggestion into consideration. It will be reviewed, and based on code quality and need addressed, we will determine acceptance. If this code addresses a feature request or issue, be sure to link to that issue.** 

### Description 

##### What does the change add or fix?

Fix mishap from last MR where duplicate Ukraine entries were copied instead of new entries for Costa Rica

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Fix mishap from last MR where duplicate Ukraine entries were copied instead of new entries for Costa Rica

---------

### Requested By

##### Who reported, requested, or paid for the change?

KFS

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/CSVPhoneCountryCode.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

[Add a no or yes with explanation here]
