### PR TITLE
Group and GroupType Import Fixes

### DIFF
--- a/Bulldozer.CSV/CSVInstance.cs
+++ b/Bulldozer.CSV/CSVInstance.cs
@@ -58,6 +58,20 @@ namespace Bulldozer.CSV
         }
 
         /// <summary>
+        /// Rock GroupLocationPickerMode enum
+        /// </summary>
+        public enum LocationSelectionMode
+        {
+            None = 0,
+            Address = 1,
+            Named = 2,
+            Point = 4,
+            Polygon = 8,
+            GroupMember = 16,
+            All = 31
+        }
+
+        /// <summary>
         /// Rock Currency Types
         /// </summary>
         /// <value>

--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -956,9 +956,9 @@ AND [Schedule].[ForeignKey] LIKE '{0}^%'
             return groupLocationsToInsert.Count;
         }
 
-        private int? GetGroupLocationTypeDVId( AddressType locationType )
+        private int? GetGroupLocationTypeDVId( AddressType addressType )
         {
-            switch ( locationType )
+            switch ( addressType )
             {
                 case AddressType.Home:
                     return this.GroupLocationTypeDVDict[Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_HOME.AsGuid()].Id;
@@ -969,11 +969,8 @@ AND [Schedule].[ForeignKey] LIKE '{0}^%'
                 case AddressType.Work:
                     return this.GroupLocationTypeDVDict[Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_WORK.AsGuid()].Id;
 
-                case AddressType.Other:
-                    return this.GroupLocationTypeDVDict[Rock.SystemGuid.DefinedValue.GROUP_LOCATION_TYPE_OTHER.AsGuid()].Id;
-
                 default:
-                    return this.GroupLocationTypeDVDict.Values.FirstOrDefault( d => !string.IsNullOrEmpty( d.ForeignKey ) && d.ForeignKey.StartsWith( ImportInstanceFKPrefix + "^" ) && d.Value == locationType.ToString() )?.Id;
+                    return this.GroupLocationTypeDVDict.Values.FirstOrDefault( d => !string.IsNullOrEmpty( d.ForeignKey ) && d.ForeignKey.StartsWith( ImportInstanceFKPrefix + "^" ) && d.Value == addressType.ToString() )?.Id;
             }
         }
 

--- a/Bulldozer.CSV/Model/GroupCsv.cs
+++ b/Bulldozer.CSV/Model/GroupCsv.cs
@@ -20,6 +20,8 @@ namespace Bulldozer.Model
 
         public string LocationId { get; set; }
 
+        public string GroupLocationType { get; set; }
+
         public int? Capacity { get; set; }
 
         public string MeetingDay { get; set; }

--- a/Bulldozer.CSV/Model/GroupTypeCsv.cs
+++ b/Bulldozer.CSV/Model/GroupTypeCsv.cs
@@ -1,5 +1,6 @@
 ﻿using CsvHelper.Configuration;
 using System;
+using static Bulldozer.CSV.CSVInstance;
 
 namespace Bulldozer.Model
 {
@@ -28,6 +29,16 @@ namespace Bulldozer.Model
         public bool? ShowInGroupList { get; set; } = true;
 
         public bool? ShowInNav { get; set; } = true;
+
+        public LocationSelectionMode? LocationSelectionMode { get; set; } = null;
+
+        public string LocationTypes { get; set; }
+
+        public bool? AllowMultipleLocations { get; set; } = false;
+
+        public bool? IsSchedulingEnabled { get; set; } = false;
+
+        public bool? EnableLocationSchedules { get; set; } = false;
 
         public DateTime? CreatedDateTime { get; set; }
 

--- a/Bulldozer/Model/GroupImport.cs
+++ b/Bulldozer/Model/GroupImport.cs
@@ -25,6 +25,8 @@ namespace Bulldozer.Model
 
         public Location Location { get; set; }
 
+        public int? GroupLocationTypeValueId { get; set; } = null;
+
         public int? Capacity { get; set; }
 
         public DateTime? CreatedDate { get; set; }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixed a couple issues related to group imports.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed bug causing parent groups to not properly be assigned.
* Enhanced GroupType import model and logic to allow better control of configuring GroupTypes on import.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/CSVInstance.cs
* Bulldozer.CSV/Maps/Group.cs
* Bulldozer.CSV/Model/GroupCsv.cs
* Bulldozer.CSV/Model/GroupTypeCsv.cs
* Bulldozer/Model/GroupImport.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
