### PR TITLE
Fixed FinancialBatch Name bug

### DIFF
--- a/Bulldozer.CSV/Maps/Benevolence.cs
+++ b/Bulldozer.CSV/Maps/Benevolence.cs
@@ -220,6 +220,10 @@ namespace Bulldozer.CSV
                             {
                                 benevolenceRequest.CampusId = requester.PrimaryCampusId;
                             }
+                            if ( requester.ConnectionStatusValueId.HasValue )
+                            {
+                                benevolenceRequest.ConnectionStatusValueId = requester.ConnectionStatusValueId;
+                            }
                             if ( requester.PhoneNumbers.Any( n => n.NumberTypeValueId.Value == homePhoneTypeDVId ) )
                             {
                                 benevolenceRequest.HomePhoneNumber = requester.PhoneNumbers.FirstOrDefault( n => n.NumberTypeValueId.Value == homePhoneTypeDVId ).NumberFormatted;

--- a/Bulldozer.CSV/Maps/Financial.cs
+++ b/Bulldozer.CSV/Maps/Financial.cs
@@ -1257,7 +1257,7 @@ namespace Bulldozer.CSV
 
             foreach ( var batch in batches )
             {
-                var batchname = !batch.Name.IsNotNullOrWhiteSpace() ? batch.Name.Truncate( 50 ) : "Unnamed Financial Batch";
+                var batchname = batch.Name.IsNotNullOrWhiteSpace() ? batch.Name.Truncate( 50 ) : "Unnamed Financial Batch";
                 var newBatch = new FinancialBatch
                 {
                     Name = batchname,


### PR DESCRIPTION
### Description 

##### What does the change add or fix?
  
Fixed bug causing FinancialBatch names to be ignored while importing. Also added logic to set Connection Status of imported Benevolence Requests when Person record is provided for Requester.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed bug causing FinancialBatch names to be ignored while importing.
* Added logic to set Connection Status of imported Benevolence Requests when Person record is provided for Requester.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/Maps/Benevolence.cs
* Bulldozer.CSV/Maps/Financial.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
