### PR TITLE
GroupMember - added support for DateTimeAdded group member field

### DIFF
--- a/Bulldozer.CSV/Maps/Group.cs
+++ b/Bulldozer.CSV/Maps/Group.cs
@@ -1153,7 +1153,8 @@ AND [Schedule].[ForeignKey] LIKE '{0}^%'
                     RoleName = textInfo.ToTitleCase( groupMemberCsv.Role.Left( 100 ) ),
                     GroupMemberStatus = groupMemberCsv.GroupMemberStatusEnum.Value,
                     GroupMemberForeignKey = groupMemberCsv.GroupMemberId.IsNotNullOrWhiteSpace() ? string.Format( "{0}^{1}", this.ImportInstanceFKPrefix, groupMemberCsv.GroupMemberId ) : string.Format( "{0}^{1}_{2}", this.ImportInstanceFKPrefix, groupMemberCsv.GroupId, groupMemberCsv.PersonId ),
-                    Note = groupMemberCsv.Note
+                    Note = groupMemberCsv.Note,
+                    DateTimeAdded = groupMemberCsv.DateTimeAdded
                 };
 
                 if ( groupMemberCsv.CreatedDate.HasValue )
@@ -1207,7 +1208,8 @@ AND [Schedule].[ForeignKey] LIKE '{0}^%'
                     ModifiedDateTime = importedDateTime,
                     Note = groupMember.Note,
                     ForeignKey = groupMember.GroupMemberForeignKey,
-                    GroupMemberStatus = groupMember.GroupMemberStatus
+                    GroupMemberStatus = groupMember.GroupMemberStatus,
+                    DateTimeAdded = groupMember.DateTimeAdded
                 };
                 if ( groupMember.GroupTypeId.HasValue )
                 {

--- a/Bulldozer.CSV/Model/GroupMemberCsv.cs
+++ b/Bulldozer.CSV/Model/GroupMemberCsv.cs
@@ -53,6 +53,8 @@ namespace Bulldozer.Model
 
         public DateTime? CreatedDate { get; set; }
 
+        public DateTime? DateTimeAdded { get; set; }
+
         public string Note { get; set; }
 
     }

--- a/Bulldozer.CSV/SampleCSVs/groupmember.csv
+++ b/Bulldozer.CSV/SampleCSVs/groupmember.csv
@@ -1,10 +1,10 @@
-GroupMemberId,GroupId,PersonId,CreatedDate,Role,GroupMemberStatus,Note
-111_25570361,111,25570361,,Leader,Active,
-111_140,111,140,5/10/2014,Member,Active,
-111_142,111,142,,Member,Inactive,
-111_145,111,145,,,Active,
-112_148,112,148,,Leader,Active,
-112_147,112,147,1/1/2015,Member,Active,
+GroupMemberId,GroupId,PersonId,CreatedDate,Role,GroupMemberStatus,Note,DateTimeAdded
+111_25570361,111,25570361,,Leader,Active,,
+111_140,111,140,5/10/2014,Member,Active,,5/15/2014
+111_142,111,142,,Member,Inactive,,
+111_145,111,145,,,Active,,
+112_148,112,148,,Leader,Active,,
+112_147,112,147,1/1/2015,Member,Active,,1/12/2015
 112_146,112,146,,,Pending,
 112_145,112,145,12/31/2015,Member,Active,
 112_25570361,112,25570361,,Member,Active,

--- a/Bulldozer/Model/GroupMemberImport.cs
+++ b/Bulldozer/Model/GroupMemberImport.cs
@@ -23,6 +23,8 @@ namespace Bulldozer.Model
 
         public DateTime? CreatedDate { get; set; }
 
+        public DateTime? DateTimeAdded { get; set; }
+
         public string Note { get; set; }
 
     }


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Added support for setting the DateTimeAdded property on group member imports

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Added support for setting the DateTimeAdded property on GroupMember objects being imported

---------

### Requested By

##### Who reported, requested, or paid for the change?

Internal

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/Maps/Group.cs
* Bulldozer.CSV/Model/GroupMemberCsv.cs
* Bulldozer.CSV/SampleCSVs/groupmember.csv
* Bulldozer/Model/GroupMemberImport.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

no
