### PR TITLE
Content Channel Import Fixes

### DIFF
--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -767,7 +767,7 @@ namespace Bulldozer.CSV
             }
 
             var contentChannelItemInstance = selectedCsvData.FirstOrDefault( i => i.RecordType == CSVInstance.RockDataType.CONTENTCHANNELITEM );
-            if ( contentChannelInstance != null )
+            if ( contentChannelItemInstance != null )
             {
                 completed += LoadContentChannelItem( contentChannelItemInstance );
             }

--- a/Bulldozer.CSV/Maps/ContentChannel.cs
+++ b/Bulldozer.CSV/Maps/ContentChannel.cs
@@ -552,7 +552,18 @@ namespace Bulldozer.CSV
                                         fk = $"{this.ImportInstanceFKPrefix}^{attributeIdString}";
                                     }
 
-                                    AddEntityAttribute( lookupContext, contentChannelItem.TypeId, "ContentChannelId", contentChannelItem.ContentChannelId.ToString(), fk, categoryName, attributeName, string.Empty, fieldTypeId, true, definedTypeForeignId, definedTypeForeignKey, attributeTypeString: attributeTypeString );
+                                    var key = string.Empty;
+
+                                    if ( !string.IsNullOrEmpty( categoryName ) )
+                                    {
+                                        key = $"{categoryName.RemoveWhitespace()}_{attributeName.RemoveWhitespace()}";
+                                    }
+                                    else
+                                    {
+                                        key = attributeName.RemoveWhitespace();
+                                    }
+
+                                    AddEntityAttribute( lookupContext, contentChannelItem.TypeId, "ContentChannelId", contentChannelItem.ContentChannelId.ToString(), fk, categoryName, attributeName, key, fieldTypeId, true, definedTypeForeignId, definedTypeForeignKey, attributeTypeString: attributeTypeString );
                                 }
                             } // end add attributes
                         } // end test for first run
@@ -612,7 +623,18 @@ namespace Bulldozer.CSV
                                         fk = attributeForeignKey;
                                     }
 
-                                    var attribute = FindEntityAttribute( lookupContext, categoryName, attributeName, contentChannelItem.TypeId, fk );
+                                    var key = string.Empty;
+
+                                    if ( !string.IsNullOrEmpty( categoryName ) )
+                                    {
+                                        key = $"{categoryName.RemoveWhitespace()}_{attributeName.RemoveWhitespace()}";
+                                    }
+                                    else
+                                    {
+                                        key = attributeName.RemoveWhitespace();
+                                    }
+
+                                    var attribute = FindEntityAttribute( lookupContext, categoryName, attributeName, contentChannelItem.TypeId, fk, key, "ContentChannelId", contentChannelItem.ContentChannelId.ToString() );
                                     AddEntityAttributeValue( lookupContext, attribute, contentChannelItem, newValue, null, true );
                                 }
                             }

--- a/Bulldozer/Utility/AddMethods.cs
+++ b/Bulldozer/Utility/AddMethods.cs
@@ -678,7 +678,7 @@ namespace Bulldozer.Utility
         /// <param name="entityTypeId">The Id of the Entity Type for the attribute</param>
         /// <param name="attributeForeignKey">The Foreign Key of the attribute</param>
         /// <returns>Attribute object of the found Entity Attribute</returns>
-        public static Attribute FindEntityAttribute( RockContext rockContext, string categoryName, string attributeName, int entityTypeId, string attributeForeignKey = null, string attributeKey = null )
+        public static Attribute FindEntityAttribute( RockContext rockContext, string categoryName, string attributeName, int entityTypeId, string attributeForeignKey = null, string attributeKey = null, string entityTypeQualifierName = null, string entityTypeQualifierValue = null )
         {
             var attributeService = new AttributeService( rockContext );
             var categoryService = new CategoryService( rockContext );
@@ -708,7 +708,7 @@ namespace Bulldozer.Utility
 
             if ( attribute == null && !string.IsNullOrWhiteSpace( attributeKey ) )
             {
-                attribute = attributeService.GetByEntityTypeId( entityTypeId ).FirstOrDefault( a => a.Key == attributeKey );
+                attribute = attributeService.GetByEntityTypeId( entityTypeId ).FirstOrDefault( a => a.Key == attributeKey && ( ( entityTypeQualifierName == null && entityTypeQualifierValue == null ) || ( a.EntityTypeQualifierColumn == entityTypeQualifierName && a.EntityTypeQualifierValue == entityTypeQualifierValue ) ) );
             }
 
             return attribute;
@@ -912,7 +912,7 @@ namespace Bulldozer.Utility
             //
             // Get a reference to the existing attribute if there is one.
             //
-            attribute = FindEntityAttribute( rockContext, categoryName, attributeName, entityTypeId, foreignKey, key );
+            attribute = FindEntityAttribute( rockContext, categoryName, attributeName, entityTypeId, foreignKey, key, entityTypeQualifierName, entityTypeQualifierValue );
             if ( attribute != null )
             {
                 newAttribute = false;
@@ -1629,7 +1629,7 @@ namespace Bulldozer.Utility
                             {
                                 DefinedTypeId = attributeValueTypes.Id,
                                 Value = v,
-                                Order = 0, 
+                                Order = 0,
                                 ForeignKey = foreignKey
                             };
 
@@ -1899,7 +1899,7 @@ namespace Bulldozer.Utility
                                 || ( c.ShortCode != null && c.ShortCode.Equals( possibleCampusName, StringComparison.OrdinalIgnoreCase ) ) )?.Id;
                 }
             }
-            
+
             if ( !returnCampusId.HasValue && addNew && ( campusIdString.IsNotNullOrWhiteSpace() || possibleCampusName.IsNotNullOrWhiteSpace() ) )
             {
                 var campusName = possibleCampusName.IsNotNullOrWhiteSpace() ? possibleCampusName : campusIdString;


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

- Make it so content channel items can be imported without importing a content channel. 
- Attach a key to finding the attributes so it can re-use existing attributes already created for the content channel. 
- That also requires entity qualifiers though, so add those as parameters as well.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

Updated Content channel import to be more robust with existing attributes.

---------

### Requested By

##### Who reported, requested, or paid for the change?

RSC

---------

### Screenshots

##### Does this update or add options to the block UI?

No

---------

### Change Log

##### What files does it affect?

- Bulldozer.CSV/CSVComponent.cs
- Bulldozer.CSV/Maps/ContentChannel.cs
- Bulldozer/Utility/AddMethods.cs

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
