### PR TITLE
Better handling of non-cash contributions

### DIFF
--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -1017,7 +1017,7 @@ namespace Bulldozer.CSV
             }
 
             // FieldTypes
-            this.FieldTypeDict = new FieldTypeService( rockContext ).Queryable().Select( a => a.Id ).ToList().Select( a => FieldTypeCache.Get( a ) ).ToDictionary( k => k.Class, v => v, StringComparer.OrdinalIgnoreCase );
+            this.FieldTypeDict = new FieldTypeService( rockContext ).Queryable().AsNoTracking().Select( a => a.Id ).ToList().Select( a => FieldTypeCache.Get( a ) ).ToDictionary( k => k.Class, v => v, StringComparer.OrdinalIgnoreCase );
 
             // Defined Types
             LoadDefinedTypeDict();
@@ -1134,7 +1134,7 @@ namespace Bulldozer.CSV
             {
                 lookupContext = new RockContext();
             }
-            var personAttributes = new AttributeService( lookupContext ).Queryable().Where( a => a.EntityTypeId == PersonEntityTypeId ).ToList();
+            var personAttributes = new AttributeService( lookupContext ).Queryable().AsNoTracking().Where( a => a.EntityTypeId == PersonEntityTypeId ).ToList();
             this.PersonAttributeDict = personAttributes.ToDictionary( k => k.Key, v => v );
         }
 
@@ -1149,7 +1149,7 @@ namespace Bulldozer.CSV
                 lookupContext = new RockContext();
             }
 
-            var familyAttributes = new AttributeService( lookupContext ).Queryable().Where( a => a.EntityTypeId == GroupEntityTypeId && a.EntityTypeQualifierColumn == "GroupTypeId" && a.EntityTypeQualifierValue == FamilyGroupTypeId.ToString() );
+            var familyAttributes = new AttributeService( lookupContext ).Queryable().AsNoTracking().Where( a => a.EntityTypeId == GroupEntityTypeId && a.EntityTypeQualifierColumn == "GroupTypeId" && a.EntityTypeQualifierValue == FamilyGroupTypeId.ToString() );
             this.FamilyAttributeDict = familyAttributes.ToDictionary( k => k.Key, v => v, StringComparer.OrdinalIgnoreCase );
         }
 
@@ -1173,7 +1173,7 @@ namespace Bulldozer.CSV
             {
                 lookupContext = new RockContext();
             }
-            var groupAttributes = new AttributeService( lookupContext ).Queryable().Where( a => a.EntityTypeId == GroupEntityTypeId ).ToList();
+            var groupAttributes = new AttributeService( lookupContext ).Queryable().AsNoTracking().Where( a => a.EntityTypeId == GroupEntityTypeId ).ToList();
             this.GroupAttributeDict = groupAttributes.ToDictionary( k => $"{k.Key}_{k.EntityTypeQualifierValue}", v => v, StringComparer.OrdinalIgnoreCase );
         }
 
@@ -1187,7 +1187,9 @@ namespace Bulldozer.CSV
             {
                 lookupContext = new RockContext();
             }
-            this.PersonSearchKeyDict = new PersonSearchKeyService( lookupContext ).Queryable()
+            this.PersonSearchKeyDict = new PersonSearchKeyService( lookupContext )
+                .Queryable()
+                .AsNoTracking()
                 .Where( o => o.ForeignKey != null && o.ForeignKey.StartsWith( ImportInstanceFKPrefix + "^" ) )
                 .ToDictionary( k => k.ForeignKey, v => v );
         }
@@ -1203,7 +1205,9 @@ namespace Bulldozer.CSV
             }
             if ( !this.UseExistingCampusIds )
             {
-                this.CampusImportDict = rockContext.Campuses.AsNoTracking()
+                this.CampusImportDict = new CampusService( rockContext )
+                    .Queryable()
+                    .AsNoTracking()
                     .Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( ImportInstanceFKPrefix + "^" ) ).ToList().ToDictionary( k => k.ForeignKey, v => v );
             }
             else
@@ -1222,7 +1226,9 @@ namespace Bulldozer.CSV
             {
                 lookupContext = new RockContext();
             }
-            this.LocationsDict = lookupContext.Locations.AsNoTracking()
+            this.LocationsDict = new LocationService( lookupContext )
+                .Queryable()
+                .AsNoTracking()
                 .Where( l => l.ForeignKey != null && l.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) )
                 .ToDictionary( k => k.ForeignKey, v => v );
         }

--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -707,7 +707,7 @@ namespace Bulldozer.CSV
                 completed += LoadScheduledTransaction( scheduledTransactionInstance );
             }
 
-            if ( this.FinancialTransactionCsvList.Count > 0 && this.FinancialTransactionDetailCsvList.Count > 0  )
+            if ( this.FinancialTransactionCsvList.Count > 0 )
             {
                 completed += ImportFinancialTransactions();
             }
@@ -1505,17 +1505,35 @@ namespace Bulldozer.CSV
 
             // Financial Transactions and Financial Transaction Details
             var financialTransactionInstance = csvInstances.FirstOrDefault( i => i.RecordType == CSVInstance.RockDataType.FinancialTransaction );
-            var financialTransactionDetailInstance = csvInstances.FirstOrDefault( i => i.RecordType == CSVInstance.RockDataType.FinancialTransactionDetail );
-            if ( financialTransactionInstance != null && financialTransactionDetailInstance != null )
+            if ( financialTransactionInstance != null )
             {
                 FinancialTransactionCsvList = LoadEntityImportListFromCsv<FinancialTransactionCsv>( financialTransactionInstance.FileName );
                 ReportProgress( 0, string.Format( "FinancialTransaction records: {0}", FinancialTransactionCsvList.Count ) );
-                FinancialTransactionDetailCsvList = LoadEntityImportListFromCsv<FinancialTransactionDetailCsv>( financialTransactionDetailInstance.FileName );
-                ReportProgress( 0, string.Format( "FinancialTransactionDetail records: {0}", FinancialTransactionDetailCsvList.Count ) );
-                var transactionLookup = FinancialTransactionCsvList.ToDictionary( k => k.Id, v => v );
-                foreach ( var transactionDetailCsv in FinancialTransactionDetailCsvList )
+
+                var financialTransactionDetailInstance = csvInstances.FirstOrDefault( i => i.RecordType == CSVInstance.RockDataType.FinancialTransactionDetail );
+                if ( financialTransactionDetailInstance != null && FinancialTransactionCsvList.Count > 0 )
                 {
-                    transactionLookup[transactionDetailCsv.TransactionId].FinancialTransactionDetails.Add( transactionDetailCsv );
+                    FinancialTransactionDetailCsvList = LoadEntityImportListFromCsv<FinancialTransactionDetailCsv>( financialTransactionDetailInstance.FileName );
+                    ReportProgress( 0, string.Format( "FinancialTransactionDetail records: {0}", FinancialTransactionDetailCsvList.Count ) );
+                    var transactionLookup = FinancialTransactionCsvList.ToDictionary( k => k.Id, v => v );
+                    var csvTranDetailsToSkip = new List<string>();
+                    foreach ( var transactionDetailCsv in FinancialTransactionDetailCsvList )
+                    {
+                        var transaction = transactionLookup.GetValueOrNull( transactionDetailCsv.TransactionId );
+                        if ( transaction != null )
+                        {
+                            transaction.FinancialTransactionDetails.Add( transactionDetailCsv );
+                        }
+                        else
+                        {
+                            csvTranDetailsToSkip.Add( transactionDetailCsv.Id );
+                        }
+                    }
+                    
+                    if ( csvTranDetailsToSkip.Any() )
+                    {
+                        FinancialTransactionDetailCsvList.RemoveAll( d => csvTranDetailsToSkip.Any( id => id == d.Id ) );
+                    }
                 }
             }
 

--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -2495,11 +2495,11 @@ namespace Bulldozer.CSV
                     definedTypeName = "Phone Type";
                     break;
                 case Rock.SystemGuid.DefinedType.PERSON_TITLE:
-                    csvEntityValues = PersonCsvList.Select( p => p.Salutation?.RemoveSpecialCharacters() ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
+                    csvEntityValues = PersonCsvList.Select( p => p.Salutation?.Trim().ReplaceSpecialCharacters( " " ) ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
                     definedTypeName = "Title";
                     break;
                 case Rock.SystemGuid.DefinedType.PERSON_SUFFIX:
-                    csvEntityValues = PersonCsvList.Select( p => p.Suffix?.RemoveSpecialCharacters() ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
+                    csvEntityValues = PersonCsvList.Select( p => p.Suffix?.Trim().ReplaceSpecialCharacters( " " ) ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
                     definedTypeName = "Suffix";
                     break;
                 case Rock.SystemGuid.DefinedType.PERSON_RECORD_STATUS_REASON:

--- a/Bulldozer.CSV/CSVComponent.cs
+++ b/Bulldozer.CSV/CSVComponent.cs
@@ -2495,11 +2495,11 @@ namespace Bulldozer.CSV
                     definedTypeName = "Phone Type";
                     break;
                 case Rock.SystemGuid.DefinedType.PERSON_TITLE:
-                    csvEntityValues = PersonCsvList.Select( p => p.Salutation ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
+                    csvEntityValues = PersonCsvList.Select( p => p.Salutation?.RemoveSpecialCharacters() ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
                     definedTypeName = "Title";
                     break;
                 case Rock.SystemGuid.DefinedType.PERSON_SUFFIX:
-                    csvEntityValues = PersonCsvList.Select( p => p.Suffix ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
+                    csvEntityValues = PersonCsvList.Select( p => p.Suffix?.RemoveSpecialCharacters() ).Where( r => !string.IsNullOrWhiteSpace( r ) ).Distinct().ToList();
                     definedTypeName = "Suffix";
                     break;
                 case Rock.SystemGuid.DefinedType.PERSON_RECORD_STATUS_REASON:

--- a/Bulldozer.CSV/Maps/FinancialTransaction.cs
+++ b/Bulldozer.CSV/Maps/FinancialTransaction.cs
@@ -59,12 +59,12 @@ namespace Bulldozer.CSV
             var fundGroupForeignKeys = this.FinancialTransactionDetailCsvList.Where( td => !string.IsNullOrWhiteSpace( td.FundraisingGroupId ) ).Select( td => ImportInstanceFKPrefix + "^" + td.FundraisingGroupId ).Distinct();
             if ( fundGroupMemberForeignKeys.Count() > 0 || fundGroupForeignKeys.Count() > 0 )
             {
-                groupMemberLookup = new GroupMemberService( rockContext ).Queryable().AsNoTracking().Where( gm => fundGroupMemberForeignKeys.Any( k => k == gm.ForeignKey ) ).ToDictionary( k => k.ForeignKey, v => v );
-                groupLookup = new GroupService( rockContext ).Queryable().AsNoTracking().Where( g => fundGroupForeignKeys.Any( k => k == g.ForeignKey ) ).ToDictionary( k => k.ForeignKey, v => v );
+                groupMemberLookup = new GroupMemberService( rockContext ).Queryable().AsNoTracking().Where( gm => fundGroupMemberForeignKeys.Contains( gm.ForeignKey ) ).ToDictionary( k => k.ForeignKey, v => v );
+                groupLookup = new GroupService( rockContext ).Queryable().AsNoTracking().Where( g => fundGroupForeignKeys.Contains( g.ForeignKey ) ).ToDictionary( k => k.ForeignKey, v => v );
             }
 
             // Look for financial gateways and create any that don't exist
-            var financialGatewayByIdLookup = new FinancialGatewayService( rockContext ).Queryable().ToDictionary( k => k.Id, v => v.Name );
+            var financialGatewayByIdLookup = new FinancialGatewayService( rockContext ).Queryable().AsNoTracking().ToDictionary( k => k.Id, v => v.Name );
             var csvGateways = this.FinancialTransactionCsvList.Where( t => t.GatewayId.IsNotNullOrWhiteSpace() ).Select( t => t.GatewayId ).Distinct();
             foreach ( var gateway in csvGateways )
             {
@@ -83,14 +83,16 @@ namespace Bulldozer.CSV
             }
 
             // Refresh gateway lookup
-            financialGatewayByIdLookup = new FinancialGatewayService( rockContext ).Queryable().ToDictionary( k => k.Id, v => v.Name );
+            financialGatewayByIdLookup = new FinancialGatewayService( rockContext ).Queryable().AsNoTracking().ToDictionary( k => k.Id, v => v.Name );
             var financialGatewayByNameLookup = financialGatewayByIdLookup.ToDictionary( k => k.Value, v => v.Key );
 
             ReportProgress( 0, string.Format( "Begin processing {0} FinancialTransaction Records...", this.FinancialTransactionCsvList.Count ) );
 
             int giverAnonymousPersonAliasId = new PersonService( rockContext ).GetOrCreateAnonymousGiverPerson().Aliases.FirstOrDefault().Id;
-            var existingImportedTransactions = new FinancialTransactionService( rockContext ).Queryable().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) );
-            var scheduledTransactionLookup = new FinancialScheduledTransactionService( rockContext ).Queryable().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) ).ToDictionary( k => k.ForeignKey, v => v.Id );
+            var existingImportedTransactions = new FinancialTransactionService( rockContext ).Queryable().AsNoTracking().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) );
+            var financialPaymentDetailLookup = new FinancialPaymentDetailService( rockContext ).Queryable().AsNoTracking().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) )
+                .Select( a => new { a.Id, a.ForeignKey } ).ToDictionary( k => k.ForeignKey, v => v.Id );
+            var scheduledTransactionLookup = new FinancialScheduledTransactionService( rockContext ).Queryable().AsNoTracking().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) ).ToDictionary( k => k.ForeignKey, v => v.Id );
             var existingImportedTransactionsHash = new HashSet<string>( existingImportedTransactions.Select( a => a.ForeignKey ).ToList() );
             var personAliasIdLookup = ImportedPeopleKeys.ToDictionary( k => k.Key, v => v.Value.PersonAliasId );
 
@@ -226,7 +228,7 @@ namespace Bulldozer.CSV
                         financialTransactionImportList.Add( newFinancialTransactionImport );
                     }
 
-                    completed += BulkImportFinancialTransactions( rockContext, financialTransactionImportList, existingImportedTransactionsHash, accountIdLookup, personAliasIdLookup, giverAnonymousPersonAliasId );
+                    completed += BulkImportFinancialTransactions( rockContext, financialTransactionImportList, financialPaymentDetailLookup, existingImportedTransactionsHash, accountIdLookup, personAliasIdLookup, giverAnonymousPersonAliasId );
                     transactionsRemainingToProcess -= csvChunk.Count;
                     workingTransactionCsvList.RemoveRange( 0, csvChunk.Count );
                     ReportPartialProgress();
@@ -251,7 +253,7 @@ namespace Bulldozer.CSV
         /// <param name="personAliasIdLookup">A guid keyed dictionary of PersonAlias ids.</param>
         /// <param name="giverAnonymousPersonAliasId">The anonymous giver PersonAliasId.</param>
         /// <returns></returns>
-        public int BulkImportFinancialTransactions( RockContext rockContext, List<FinancialTransactionImport> financialTransactionImports, HashSet<string> existingImportedTransactionsHash, Dictionary<string, int> accountIdLookup, Dictionary<string, int> personAliasIdLookup, int giverAnonymousPersonAliasId )
+        public int BulkImportFinancialTransactions( RockContext rockContext, List<FinancialTransactionImport> financialTransactionImports, Dictionary<string, int> financialPaymentDetailLookup, HashSet<string> existingImportedTransactionsHash, Dictionary<string, int> accountIdLookup, Dictionary<string, int> personAliasIdLookup, int giverAnonymousPersonAliasId )
         {
             var newFinancialTransactionImports = financialTransactionImports.Where( a => !existingImportedTransactionsHash.Contains( a.FinancialTransactionForeignKey ) ).ToList();
             var existingFinancialTransactionImports = financialTransactionImports.Where( a => existingImportedTransactionsHash.Contains( a.FinancialTransactionForeignKey ) ).ToList();
@@ -262,21 +264,24 @@ namespace Bulldozer.CSV
             var financialPaymentDetailToInsert = new List<FinancialPaymentDetail>();
             foreach ( var financialTransactionImport in newFinancialTransactionImports )
             {
-                var newFinancialPaymentDetail = new FinancialPaymentDetail
+                if ( !financialPaymentDetailLookup.GetValueOrNull( financialTransactionImport.FinancialTransactionForeignKey ).HasValue )
                 {
-                    CurrencyTypeValueId = financialTransactionImport.CurrencyTypeValueId,
-                    ForeignKey = financialTransactionImport.FinancialTransactionForeignKey,
-                    CreatedDateTime = financialTransactionImport.CreatedDateTime.ToSQLSafeDate() ?? importDateTime,
-                    ModifiedDateTime = financialTransactionImport.ModifiedDateTime.ToSQLSafeDate() ?? importDateTime,
-                    CreditCardTypeValueId = financialTransactionImport.CreditCardTypeValueId
-                };
+                    var newFinancialPaymentDetail = new FinancialPaymentDetail
+                    {
+                        CurrencyTypeValueId = financialTransactionImport.CurrencyTypeValueId,
+                        ForeignKey = financialTransactionImport.FinancialTransactionForeignKey,
+                        CreatedDateTime = financialTransactionImport.CreatedDateTime.ToSQLSafeDate() ?? importDateTime,
+                        ModifiedDateTime = financialTransactionImport.ModifiedDateTime.ToSQLSafeDate() ?? importDateTime,
+                        CreditCardTypeValueId = financialTransactionImport.CreditCardTypeValueId
+                    };
 
-                financialPaymentDetailToInsert.Add( newFinancialPaymentDetail );
+                    financialPaymentDetailToInsert.Add( newFinancialPaymentDetail );
+                }
             }
 
             rockContext.BulkInsert( financialPaymentDetailToInsert );
 
-            var financialPaymentDetailLookup = new FinancialPaymentDetailService( rockContext ).Queryable().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) )
+            financialPaymentDetailLookup = new FinancialPaymentDetailService( rockContext ).Queryable().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) )
                 .Select( a => new { a.Id, a.ForeignKey } ).ToDictionary( k => k.ForeignKey, v => v.Id );
 
             // Prepare and Insert FinancialTransactions
@@ -336,7 +341,7 @@ namespace Bulldozer.CSV
 
             rockContext.BulkInsert( financialTransactionsToInsert );
 
-            var financialTransactionIdLookup = new FinancialTransactionService( rockContext ).Queryable().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) )
+            var financialTransactionIdLookup = new FinancialTransactionService( rockContext ).Queryable().AsNoTracking().Where( a => a.ForeignKey != null && a.ForeignKey.StartsWith( this.ImportInstanceFKPrefix + "^" ) )
                 .Select( a => new { a.Id, a.ForeignKey } )
                 .ToList().ToDictionary( k => k.ForeignKey, v => v.Id );
 

--- a/Bulldozer.CSV/Maps/Person.cs
+++ b/Bulldozer.CSV/Maps/Person.cs
@@ -297,13 +297,13 @@ namespace Bulldozer.CSV
 
                 if ( !string.IsNullOrEmpty( personCsv.Salutation ) )
                 {
-                    var prefix = personCsv.Salutation.RemoveSpecialCharacters();
+                    var prefix = personCsv.Salutation.Trim().ReplaceSpecialCharacters( " " );
                     newPerson.TitleValueId = TitleDVDict[prefix]?.Id;
                 }
 
                 if ( !string.IsNullOrEmpty( personCsv.Suffix ) )
                 {
-                    var suffix = personCsv.Suffix.RemoveSpecialCharacters();
+                    var suffix = personCsv.Suffix.Trim().ReplaceSpecialCharacters( " " );
                     newPerson.SuffixValueId = SuffixDVDict[suffix]?.Id;
                 }
 


### PR DESCRIPTION
### Description 

##### What does the change add or fix?

Fixed issue causing transactions with no transaction details to be skipped and not imported. This was potentially affecting import of non-cash contributions. Also fixed some logic causing potential discprepancies between the logic pre-building the defined values for salutations and suffixes with their respective logic in the People import mapping.

---------

### Release Notes 

##### What does the change add or fix in a succinct statement that will be read by clients?

* Fixed issue causing transactions with no transaction details to be skipped and not imported.
* Improved performance of financial transaction import in certain scenarios.
* Fixed issue potentially causing duplicate non-matching suffix and/or saluation defined values to be created in some scenarios.

---------

### Requested By

##### Who reported, requested, or paid for the change?

Warranty

---------

### Screenshots

##### Does this update or add options to the block UI?

no

---------

### Change Log

##### What files does it affect?

* Bulldozer.CSV/CSVComponent.cs. 

---------

### Migrations/External Impacts

##### Is it a breaking change for other versions/clients?

No
